### PR TITLE
Add quotes around format parameters to ensure that flake8 runs correctly

### DIFF
--- a/src/client/linters/flake8.ts
+++ b/src/client/linters/flake8.ts
@@ -5,7 +5,7 @@ import * as baseLinter from './baseLinter';
 import * as settings from './../common/configSettings';
 import {OutputChannel} from 'vscode';
 
-const FLAKE8_COMMANDLINE = " --format=%(row)d,%(col)d,%(code)s,%(code)s:%(text)s";
+const FLAKE8_COMMANDLINE = " --format='%(row)d,%(col)d,%(code)s,%(code)s:%(text)s'";
 
 export class Linter extends baseLinter.BaseLinter {
     constructor(rootDir: string, pythonSettings: settings.IPythonSettings, outputChannel: OutputChannel) {


### PR DESCRIPTION
I noticed when trying to run flake8, I wasn't seeing the editor reflect the flake8 issues in my code. Digging around I noticed that the format string needed some quotes so here they are.