### PR TITLE
fix for casesensitive filename main.js -> Main.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
             "python"
           ]
         },
-        "program": "./out/client/debugger/main.js",
+        "program": "./out/client/debugger/Main.js",
         "runtime": "node",
         "configurationAttributes": {
           "launch": {


### PR DESCRIPTION
linux vscode needs this