### PR TITLE
Added quotes around format-commands to prevent space errors.

### DIFF
--- a/src/client/formatters/autoPep8Formatter.ts
+++ b/src/client/formatters/autoPep8Formatter.ts
@@ -19,6 +19,6 @@ export class AutoPep8Formatter extends BaseFormatter {
     public formatDocument(document: vscode.TextDocument, options: vscode.FormattingOptions, token: vscode.CancellationToken): Thenable<vscode.TextEdit[]> {
         var autopep8Path = this.pythonSettings.formatting.autopep8Path;
         var fileDir = path.dirname(document.uri.fsPath);
-        return super.provideDocumentFormattingEdits(document, options, token, `${autopep8Path} ${document.uri.fsPath}`);
+        return super.provideDocumentFormattingEdits(document, options, token, `${autopep8Path} "${document.uri.fsPath}"`);
     }
 }

--- a/src/client/formatters/yapfFormatter.ts
+++ b/src/client/formatters/yapfFormatter.ts
@@ -19,6 +19,6 @@ export class YapfFormatter extends BaseFormatter {
     public formatDocument(document: vscode.TextDocument, options: vscode.FormattingOptions, token: vscode.CancellationToken): Thenable<vscode.TextEdit[]> {
         var yapfPath = this.pythonSettings.formatting.yapfPath;
         var fileDir = path.dirname(document.uri.fsPath);
-        return super.provideDocumentFormattingEdits(document, options, token, `${yapfPath} ${document.uri.fsPath}`);
+        return super.provideDocumentFormattingEdits(document, options, token, `${yapfPath} "${document.uri.fsPath}"`);
     }
 }


### PR DESCRIPTION
Format fails when directories contain spaces.

Windows 10:
> Command failed: C:\Windows\system32\cmd.exe /s /c "yapf c:\tmp dir\test.py"
yapf: Input filenames did not match any python files

Ubuntu 14.04:
>Command failed: /bin/sh -c autopep8 /vagrant/tmp dir/test.py
usage: autopep8 [-h] [--version] [-v] [-d] [-i] [--global-config filename]
                [--ignore-local-config] [-r] [-j n] [-p n] [-a]
                [--experimental] [--exclude globs] [--list-fixes]
                [--ignore errors] [--select errors] [--max-line-length n]
                [--line-range line line]
                [files [files ...]]
autopep8: error: autopep8 only takes one filename as argument unless the "--in-place" or "--diff" args are used

Tested this branch in both OS's listed above.