### PR TITLE
Enable all_scopes for jedi.api.name while listing all symbols

### DIFF
--- a/pythonFiles/completion.py
+++ b/pythonFiles/completion.py
@@ -278,7 +278,8 @@ class JediCompletion(object):
             return self._write_response(self._serialize_definitions(
                 jedi.api.names(
                     source=request['source'], 
-                    path=request.get('path', '')), 
+                    path=request.get('path', ''),
+                    all_scopes=True),
                 request['id']))
                 
         script = jedi.api.Script(


### PR DESCRIPTION
fix ISSUE : https://github.com/DonJayamanne/pythonVSCode/issues/75
Now that, we could list all symbols within a python source file (including methods)