### PR TITLE
WIP: Allow pylint CLI args to be configurable

### DIFF
--- a/src/client/common/configSettings.ts
+++ b/src/client/common/configSettings.ts
@@ -35,6 +35,7 @@ export interface ILintingSettings {
     maxNumberOfProblems: number;
     pylintCategorySeverity: IPylintCategorySeverity;
     pylintPath: string;
+    pylintCLIArgs: string;
     pep8Path: string;
     flake8Path: string;
     pydocStylePath: string;

--- a/src/client/linters/pylint.ts
+++ b/src/client/linters/pylint.ts
@@ -30,7 +30,11 @@ export class Linter extends baseLinter.BaseLinter {
         }
 
         var pylintPath = this.pythonSettings.linting.pylintPath;
-        var cmdLine = `${pylintPath} ${PYLINT_COMMANDLINE} "${filePath}"`;
+        var pylintCLIArgs = this.pythonSettings.linting.pylintCLIArgs;
+        if (!pylintCLIArgs) {
+            pylintCLIArgs = PYLINT_COMMANDLINE;
+        }
+        var cmdLine = `${pylintPath} ${pylintCLIArgs} "${filePath}"`;
         return new Promise<baseLinter.ILintMessage[]>((resolve, reject) => {
             this.run(cmdLine, filePath, txtDocumentLines, workspace.rootPath).then(messages=> {
                 messages.forEach(msg=> {


### PR DESCRIPTION
## What?

Expose a different configuration variable for specifying CLI arguments that can be passed to pylint. 

## Why?

Though the plugin allows one to specify a rc file in workspace root, there can be use cases when it's best for the user to supply the path through ``--rc-file`` argument. Though this can be done by overriding the ``pylintPath`` variable, it is counter intuitive. Path always means location to actual binary. 

## Questions for the maintainer

1. Do you like this change? 
2. Do you want me to fix pep8, flake8 to also take in CLI args via a configuration argument? 
3. Any contribution guidelines? How do I run tests? New to typescript here.
4. What's the best place to ask questions? IRC or email? 

Thanks for the plugin. I would like to help with other contributions as well whenever I can. 