### PR TITLE
Explicitly indicate MIT license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Linting, Debugging (multi-threaded, remote), Intellisense, auto-completion, code formatting, snippets, and more.",
   "version": "0.3.9",
   "publisher": "donjayamanne",
-  "license": "SEE LICENSE IN LICENSE or README.MD",
+  "license": "MIT",
   "homepage": "https://github.com/DonJayamanne/pythonVSCode/blob/master/README.md",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Since it's not a custom license it should just state the [SPDX identifier](https://spdx.org/licenses/), see https://docs.npmjs.com/files/package.json#license