### PR TITLE
Set Workspace Interpreter command

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
       },
       {
         "command": "python.setInterpreter",
-        "title": "Set Workspace Interpreter",
+        "title": "Select Workspace Interpreter",
         "category": "Python"
       },
       {
@@ -236,7 +236,7 @@
             "type": "python",
             "request": "launch",
             "stopOnEntry": true,
-            "pythonPath" :"${config.python.pythonPath}",
+            "pythonPath": "${config.python.pythonPath}",
             "program": "${file}",
             "debugOptions": [
               "WaitOnAbnormalExit",
@@ -249,7 +249,7 @@
             "type": "python",
             "request": "launch",
             "stopOnEntry": true,
-            "pythonPath" :"${config.python.pythonPath}",
+            "pythonPath": "${config.python.pythonPath}",
             "program": "${file}",
             "externalConsole": true,
             "debugOptions": [
@@ -262,7 +262,7 @@
             "type": "python",
             "request": "launch",
             "stopOnEntry": true,
-            "pythonPath" :"${config.python.pythonPath}",
+            "pythonPath": "${config.python.pythonPath}",
             "program": "${workspaceRoot}/manage.py",
             "args": [
               "runserver",
@@ -280,7 +280,7 @@
             "type": "python",
             "request": "launch",
             "stopOnEntry": true,
-            "pythonPath" :"${config.python.pythonPath}",
+            "pythonPath": "${config.python.pythonPath}",
             "program": "${workspaceRoot}/console.py",
             "args": [
               "dev",
@@ -301,7 +301,7 @@
             "remoteRoot": "${workspaceRoot}",
             "port": 3000,
             "secret": "my_secret",
-            "host":"localhost"
+            "host": "localhost"
           }
         ]
       }
@@ -599,6 +599,7 @@
     "test": "node ./node_modules/vscode/bin/test"
   },
   "dependencies": {
+    "copy-paste": "^1.3.0",
     "diff-match-patch": "^1.0.0",
     "fs-extra": "^0.30.0",
     "line-by-line": "^0.1.4",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
   "activationEvents": [
     "onLanguage:python",
     "onCommand:python.sortImports",
-    "onCommand:python.runtests"
+    "onCommand:python.runtests",
+    "onCommand:python.setInterpreter"
   ],
   "main": "./out/client/extension",
   "contributes": {
@@ -54,6 +55,11 @@
       {
         "command": "python.runtests",
         "title": "Run Unit Tests",
+        "category": "Python"
+      },
+      {
+        "command": "python.setInterpreter",
+        "title": "Set Workspace Interpreter",
         "category": "Python"
       },
       {

--- a/src/client/common/utils.ts
+++ b/src/client/common/utils.ts
@@ -5,7 +5,7 @@ import * as fs from 'fs';
 import * as child_process from 'child_process';
 import * as settings from './configSettings';
 
-const IS_WINDOWS = /^win/.test(process.platform);
+export const IS_WINDOWS = /^win/.test(process.platform);
 const PATH_VARIABLE_NAME = IS_WINDOWS ? 'Path' : 'PATH';
 
 const PathValidity: Map<string, boolean> = new Map<string, boolean>();
@@ -49,7 +49,7 @@ export function getPythonInterpreterDirectory(): Promise<string> {
             return resolve('');
         }
 
-        // If we can execute the python, then get the path from the fullyqualitified name
+        // If we can execute the python, then get the path from the fully qualified name
         child_process.execFile(pythonFileName, ['-c', 'print(1234)'], (error, stdout, stderr) => {
             // Yes this is a valid python path
             if (stdout.startsWith('1234')) {

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -19,6 +19,7 @@ import * as telemetryHelper from './common/telemetry';
 import * as telemetryContracts from './common/telemetryContracts';
 import {PythonCodeActionsProvider} from './providers/codeActionProvider';
 import {activateSimplePythonRefactorProvider} from './providers/simpleRefactorProvider';
+import {activateSetInterpreterProvider} from './providers/setInterpreterProvider';
 
 const PYTHON: vscode.DocumentFilter = { language: 'python', scheme: 'file' };
 let unitTestOutChannel: vscode.OutputChannel;
@@ -47,6 +48,7 @@ export function activate(context: vscode.ExtensionContext) {
 
     sortImports.activate(context, formatOutChannel);
     activateUnitTestProvider(context, pythonSettings, unitTestOutChannel);
+    activateSetInterpreterProvider(context, pythonSettings);
     activateSimplePythonRefactorProvider(context, formatOutChannel);
     context.subscriptions.push(activateFormatOnSaveProvider(PYTHON, pythonSettings, formatOutChannel, vscode.workspace.rootPath));
 

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -48,7 +48,7 @@ export function activate(context: vscode.ExtensionContext) {
 
     sortImports.activate(context, formatOutChannel);
     activateUnitTestProvider(context, pythonSettings, unitTestOutChannel);
-    activateSetInterpreterProvider(context, pythonSettings);
+    activateSetInterpreterProvider();
     activateSimplePythonRefactorProvider(context, formatOutChannel);
     context.subscriptions.push(activateFormatOnSaveProvider(PYTHON, pythonSettings, formatOutChannel, vscode.workspace.rootPath));
 

--- a/src/client/providers/setInterpreterProvider.ts
+++ b/src/client/providers/setInterpreterProvider.ts
@@ -116,7 +116,7 @@ function setInterpreter() {
         settingsPath = workspaceSettingsPath()
     } catch (e) {
         // We aren't even in a workspace
-        vscode.window.showInformationMessage("The interpreter can only be set within a workspace (open a folder)")
+        vscode.window.showErrorMessage("The interpreter can only be set within a workspace (open a folder)")
         return
     }
     vscode.workspace.openTextDocument(settingsPath)
@@ -129,6 +129,6 @@ function setInterpreter() {
             () => {
                 // The user doesn't have any workspace settings!
                 // Prompt them to create one first
-                vscode.window.showInformationMessage("No workspace settings file. First, run 'Preferences: Open Workspace Settings' to create one." )
+                vscode.window.showErrorMessage("No workspace settings file. First, run 'Preferences: Open Workspace Settings' to create one." )
                 })
 }

--- a/src/client/providers/setInterpreterProvider.ts
+++ b/src/client/providers/setInterpreterProvider.ts
@@ -56,7 +56,7 @@ function suggestionToQuickPickItem(suggestion: PythonPathSuggestion) : vscode.Qu
     return {
         label: suggestion.label,
         description: suggestion.type,
-        detail: suggestion.path
+        detail: utils.IS_WINDOWS ? suggestion.path.replace(/\\/g, "/") : suggestion.path
     }
 }
 

--- a/src/client/providers/setInterpreterProvider.ts
+++ b/src/client/providers/setInterpreterProvider.ts
@@ -14,10 +14,7 @@ interface PythonPathSuggestion {
     type: string   // conda
 }
 
-let currentPythonPath: string 
-
-export function activateSetInterpreterProvider(context: vscode.ExtensionContext, settings: settings.IPythonSettings) {
-    currentPythonPath = settings.pythonPath
+export function activateSetInterpreterProvider() {
     vscode.commands.registerCommand("python.setInterpreter", setInterpreter);
 }
 
@@ -79,7 +76,7 @@ function setPythonPath(path: String) {
 }
 
 function setInterpreter() {
-
+    const currentPythonPath = settings.PythonSettings.getInstance().pythonPath;
     const quickPickOptions: vscode.QuickPickOptions = {
         matchOnDetail: true,
         matchOnDescription: false,

--- a/src/client/providers/setInterpreterProvider.ts
+++ b/src/client/providers/setInterpreterProvider.ts
@@ -4,6 +4,7 @@ import * as path  from "path";
 import * as vscode from "vscode";
 import * as settings from "./../common/configSettings";
 import * as utils from "./../common/utils";
+let ncp = require("copy-paste");
 
 // where to find the Python binary within a conda env
 const CONDA_RELATIVE_PY_PATH = utils.IS_WINDOWS ? ['python'] : ['bin', 'python'] 
@@ -69,10 +70,16 @@ function suggestPythonPaths(): Promise<vscode.QuickPickItem[]> {
     );
 }
 
-function setPythonPath(path: String) {
+function setPythonPath(path: string) {
     // Waiting on https://github.com/Microsoft/vscode/issues/1396
-    // For now, just a stub.
-    vscode.window.showInformationMessage(`Setting pythonPath: ${path}`);
+    // For now, just let the user copy this to clipboard
+    const copy_msg =  "Copy to Clipboard"
+    vscode.window.showInformationMessage(path, copy_msg)
+        .then(item => {
+            if (item === copy_msg) {
+                ncp.copy(path)
+            }
+        })
 }
 
 function setInterpreter() {

--- a/src/client/providers/setInterpreterProvider.ts
+++ b/src/client/providers/setInterpreterProvider.ts
@@ -70,14 +70,21 @@ function suggestPythonPaths(): Promise<vscode.QuickPickItem[]> {
     );
 }
 
-function setPythonPath(path: string) {
+function setPythonPath(pythonPath: string) {
     // Waiting on https://github.com/Microsoft/vscode/issues/1396
     // For now, just let the user copy this to clipboard
     const copy_msg =  "Copy to Clipboard"
-    vscode.window.showInformationMessage(path, copy_msg)
+
+    // If the user already has .vscode/settings.json in the workspace
+    // open it for them
+    const workspaceSettingsPath = path.join(vscode.workspace.rootPath, '.vscode', 'settings.json')
+    vscode.workspace.openTextDocument(workspaceSettingsPath)
+        .then(doc => vscode.window.showTextDocument(doc));
+    
+    vscode.window.showInformationMessage(pythonPath, copy_msg)
         .then(item => {
             if (item === copy_msg) {
-                ncp.copy(path)
+                ncp.copy(pythonPath)
             }
         })
 }

--- a/src/client/providers/setInterpreterProvider.ts
+++ b/src/client/providers/setInterpreterProvider.ts
@@ -1,0 +1,95 @@
+"use strict";
+import * as child_process from 'child_process';
+import * as path  from "path";
+import * as vscode from "vscode";
+import * as settings from "./../common/configSettings";
+import * as utils from "./../common/utils";
+
+// where to find the Python binary within a conda env
+const CONDA_RELATIVE_PY_PATH = utils.IS_WINDOWS ? ['python'] : ['bin', 'python'] 
+
+interface PythonPathSuggestion {
+    label: string, // myenvname
+    path: string,  // /full/path/to/bin/python
+    type: string   // conda
+}
+
+let currentPythonPath: string 
+
+export function activateSetInterpreterProvider(context: vscode.ExtensionContext, settings: settings.IPythonSettings) {
+    currentPythonPath = settings.pythonPath
+    vscode.commands.registerCommand("python.setInterpreter", setInterpreter);
+}
+
+function suggestionsFromConda(): Promise<PythonPathSuggestion[]> {
+    return new Promise((resolve, reject) => {
+        // interrogate conda (if it's on the path) to find all environments
+        child_process.execFile('conda', ['info', '--json'], (error, stdout, stderr) => {
+            try {
+                const info = JSON.parse(stdout)
+
+                // envs reported as e.g.: /Users/bob/miniconda3/envs/someEnv
+                const envs = <string[]>info['envs']
+
+                // The root of the conda environment is itself a Python interpreter
+                envs.push(info["default_prefix"])
+
+                const suggestions = envs.map(env => ({
+                    label: path.basename(env),  // e.g. someEnv, miniconda3
+                    path: path.join(env, ...CONDA_RELATIVE_PY_PATH),
+                    type: 'conda',
+                }))
+                resolve(suggestions)
+            } catch (e) {
+                // Failed because either:
+                //   1. conda is not installed
+                //   2. `conda info --json` has changed signature
+                //   3. output of `conda info --json` has changed in structure
+                // In all cases, we can't offer conda pythonPath suggestions.
+                return resolve([])
+            }
+        })
+    });
+}
+
+function suggestionToQuickPickItem(suggestion: PythonPathSuggestion) : vscode.QuickPickItem {
+    return {
+        label: suggestion.label,
+        description: suggestion.type,
+        detail: suggestion.path
+    }
+}
+
+function suggestPythonPaths(): Promise<vscode.QuickPickItem[]> {
+
+    // For now we only interrogate conda for suggestions.
+    const condaSuggestions = suggestionsFromConda();
+
+    // Here we could also look for virtualenvs/default install locations...
+
+    return condaSuggestions.then(
+        suggestions => suggestions.map(suggestionToQuickPickItem)
+    );
+}
+
+function setPythonPath(path: String) {
+    // Waiting on https://github.com/Microsoft/vscode/issues/1396
+    // For now, just a stub.
+    vscode.window.showInformationMessage(`Setting pythonPath: ${path}`);
+}
+
+function setInterpreter() {
+
+    const quickPickOptions: vscode.QuickPickOptions = {
+        matchOnDetail: true,
+        matchOnDescription: false,
+        placeHolder: `current: ${currentPythonPath}`
+    }
+
+    vscode.window.showQuickPick(suggestPythonPaths(), quickPickOptions).then(
+        value => {
+            if (value !== undefined) {
+                setPythonPath(value.detail);
+            }
+        })
+}


### PR DESCRIPTION
This adds a new Command Palette entry for Python which provides suggestions for Python interpreters you may wish to set in the workspace settings:
![Python: Set Workspace Interpreter](https://cloud.githubusercontent.com/assets/1312873/17837213/8060763c-67a4-11e6-9a06-cc71c23e4a8f.png)


For now, only conda environments are detected (by interrogating the conda binary), but it will be easy to add support for other common Python interpreter locations.

See #257 for more motivation.

VSCode doesn't yet include support for setting workspace settings from an extension, so for now just a message is printed to demonstrate where we would update `.vscode/settings.json`.

#### Todo

As a minimum before this can be merged:
- [x] Test on Windows
- [x] Test in absence of conda
- [ ] Add documentation ([here on the wiki](https://github.com/DonJayamanne/pythonVSCode/wiki/Python-Path-and-Version#virtual-environments) I guess?)
- [ ] Add default Python install locations (e.g. `/usr/local`)

#### Extensions

Could be handled in separate PRs:
- [x] Test for existence of suggestions and filter based on existence
- [ ] Detect Python version and include in hint
- [ ] Add virtualenv detection
- [x] Add ability to copy selected path to clipboard
- [ ] Actually set the workspace setting (blocked by Microsoft/vscode#1396, could write our own as stopgap?)
- [ ] Add unit tests for new functionality
