### PR TITLE
[Work In Progress] execute file in terminal support

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,13 +103,18 @@
           "command": "python.refactorExtractVariable",
           "title": "Refactor: Extract Variable",
           "group": "Refactor",
-          "when": "editorHasSelection"
+          "when": "editorHasSelection && resourceLangId == python"
         },
         {
           "command": "python.refactorExtractMethod",
           "title": "Refactor: Extract Method",
           "group": "Refactor",
-          "when": "editorHasSelection"
+          "when": "editorHasSelection && resourceLangId == python"
+        },
+        {
+          "when": "resourceLangId == python",
+          "command": "python.execInTerminal",
+          "group": "Python"
         }
       ],
       "explorer/context": [
@@ -117,7 +122,7 @@
           "command": "python.runtests",
           "group": "Python"
         },
-          {
+        {
           "when": "resourceLangId == python",
           "command": "python.execInTerminal",
           "group": "Python"

--- a/package.json
+++ b/package.json
@@ -116,6 +116,11 @@
         {
           "command": "python.runtests",
           "group": "Python"
+        },
+          {
+          "when": "resourceLangId == python",
+          "command": "python.execInTerminal",
+          "group": "Python"
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   ],
   "activationEvents": [
     "onLanguage:python",
+    "onCommand:python.execInTerminal",
     "onCommand:python.sortImports",
     "onCommand:python.runtests",
     "onCommand:python.setInterpreter",
@@ -58,6 +59,11 @@
       {
         "command": "python.runtests",
         "title": "Run Unit Tests",
+        "category": "Python"
+      },
+      {
+        "command": "python.execInTerminal",
+        "title": "Run Python file in Terminal",
         "category": "Python"
       },
       {

--- a/src/client/common/constants.ts
+++ b/src/client/common/constants.ts
@@ -1,5 +1,4 @@
 
-
 export const PythonLanguage = { language: 'python', scheme: 'file' };
 
 export namespace Commands {

--- a/src/client/common/constants.ts
+++ b/src/client/common/constants.ts
@@ -1,4 +1,5 @@
 export var Command_Set_Interpreter = 'python.setInterpreter';
+export var Command_Exec_In_Terminal = 'python.execInTerminal';
 export var Command_Tests_View_UI = 'python.viewTests';
 export var Command_Tests_Discover = 'python.discoverTests';
 export var Command_Tests_Run_Failed = 'python.runFailedTests';

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -19,6 +19,7 @@ import * as telemetryContracts from './common/telemetryContracts';
 import {PythonCodeActionsProvider} from './providers/codeActionProvider';
 import {activateSimplePythonRefactorProvider} from './providers/simpleRefactorProvider';
 import {activateSetInterpreterProvider} from './providers/setInterpreterProvider';
+import {activateExecInTerminalProvider} from './providers/execInTerminalProvider';
 import * as tests from './unittest/main';
 
 const PYTHON: vscode.DocumentFilter = { language: 'python', scheme: 'file' };
@@ -48,6 +49,7 @@ export function activate(context: vscode.ExtensionContext) {
 
     sortImports.activate(context, formatOutChannel);
     activateSetInterpreterProvider();
+    activateExecInTerminalProvider();
     activateSimplePythonRefactorProvider(context, formatOutChannel);
     context.subscriptions.push(activateFormatOnSaveProvider(PYTHON, pythonSettings, formatOutChannel, vscode.workspace.rootPath));
 

--- a/src/client/providers/execInTerminalProvider.ts
+++ b/src/client/providers/execInTerminalProvider.ts
@@ -10,7 +10,6 @@ function execInTerminal(fileUri?: vscode.Uri) {
     const currentPythonPath = settings.PythonSettings.getInstance().pythonPath;
     let filePath: string;
 
-    console.log(fileUri);
     if (fileUri === undefined) {
         const activeEditor = vscode.window.activeTextEditor;
         if (activeEditor !== undefined) {

--- a/src/client/providers/execInTerminalProvider.ts
+++ b/src/client/providers/execInTerminalProvider.ts
@@ -1,0 +1,36 @@
+"use strict";
+import * as child_process from 'child_process';
+import * as path  from "path";
+import * as vscode from "vscode";
+import * as settings from "./../common/configSettings";
+import * as utils from "./../common/utils";
+
+export function activateExecInTerminalProvider() {
+    vscode.commands.registerCommand("python.execInTerminal", execInTerminal);
+}
+
+function execInTerminal(filePath: string) {
+    const currentPythonPath = settings.PythonSettings.getInstance().pythonPath;
+
+    console.log(filePath);
+    if (filePath === undefined) {
+        const activeEditor = vscode.window.activeTextEditor;
+        if (activeEditor !== undefined) {
+            if (!activeEditor.document.isUntitled) {
+                filePath = activeEditor.document.fileName;
+            } else {
+                vscode.window.showErrorMessage('The active file needs to be saved before it can be run');
+                return;
+            } 
+        } else {
+            vscode.window.showErrorMessage('No open file to run in terminal');
+            return;
+        }
+    }
+
+    const terminal = (<any>vscode.window).createTerminal(`Ext Terminal`);
+    setTimeout(() => {
+        terminal.sendText(`${currentPythonPath} ${filePath}`);
+    }, 1000);
+
+}

--- a/src/client/providers/execInTerminalProvider.ts
+++ b/src/client/providers/execInTerminalProvider.ts
@@ -1,9 +1,10 @@
 "use strict";
 import * as vscode from "vscode";
-import * as settings from "./../common/configSettings";
+import * as settings from "../common/configSettings";
+import { Commands } from '../common/constants';
 
 export function activateExecInTerminalProvider() {
-    vscode.commands.registerCommand("python.execInTerminal", execInTerminal);
+    vscode.commands.registerCommand(Commands.Exec_In_Terminal, execInTerminal);
 }
 
 function execInTerminal(fileUri?: vscode.Uri) {

--- a/src/client/providers/execInTerminalProvider.ts
+++ b/src/client/providers/execInTerminalProvider.ts
@@ -1,9 +1,6 @@
 "use strict";
-import * as child_process from 'child_process';
-import * as path  from "path";
 import * as vscode from "vscode";
 import * as settings from "./../common/configSettings";
-import * as utils from "./../common/utils";
 
 export function activateExecInTerminalProvider() {
     vscode.commands.registerCommand("python.execInTerminal", execInTerminal);
@@ -29,6 +26,8 @@ function execInTerminal(filePath: string) {
     }
 
     const terminal = (<any>vscode.window).createTerminal(`Ext Terminal`);
+    // Temporary workaround until a promise of terminal readiness is available:
+    // https://github.com/Tyriar/vscode-terminal-api-example/issues/2
     setTimeout(() => {
         terminal.sendText(`${currentPythonPath} ${filePath}`);
     }, 1000);

--- a/src/client/providers/execInTerminalProvider.ts
+++ b/src/client/providers/execInTerminalProvider.ts
@@ -6,11 +6,12 @@ export function activateExecInTerminalProvider() {
     vscode.commands.registerCommand("python.execInTerminal", execInTerminal);
 }
 
-function execInTerminal(filePath: string) {
+function execInTerminal(fileUri?: vscode.Uri) {
     const currentPythonPath = settings.PythonSettings.getInstance().pythonPath;
+    let filePath: string;
 
-    console.log(filePath);
-    if (filePath === undefined) {
+    console.log(fileUri);
+    if (fileUri === undefined) {
         const activeEditor = vscode.window.activeTextEditor;
         if (activeEditor !== undefined) {
             if (!activeEditor.document.isUntitled) {
@@ -23,9 +24,11 @@ function execInTerminal(filePath: string) {
             vscode.window.showErrorMessage('No open file to run in terminal');
             return;
         }
+    } else {
+        filePath = fileUri.fsPath;
     }
 
-    const terminal = (<any>vscode.window).createTerminal(`Ext Terminal`);
+    const terminal = (<any>vscode.window).createTerminal(`Python`);
     // Temporary workaround until a promise of terminal readiness is available:
     // https://github.com/Tyriar/vscode-terminal-api-example/issues/2
     setTimeout(() => {

--- a/src/client/providers/execInTerminalProvider.ts
+++ b/src/client/providers/execInTerminalProvider.ts
@@ -14,7 +14,12 @@ function execInTerminal(fileUri?: vscode.Uri) {
         const activeEditor = vscode.window.activeTextEditor;
         if (activeEditor !== undefined) {
             if (!activeEditor.document.isUntitled) {
-                filePath = activeEditor.document.fileName;
+                if (activeEditor.document.languageId == "python") {
+                    filePath = activeEditor.document.fileName;
+                } else {
+                    vscode.window.showErrorMessage('The active file is not a Python source file');
+                    return;
+                }
             } else {
                 vscode.window.showErrorMessage('The active file needs to be saved before it can be run');
                 return;

--- a/src/client/providers/execInTerminalProvider.ts
+++ b/src/client/providers/execInTerminalProvider.ts
@@ -34,10 +34,6 @@ function execInTerminal(fileUri?: vscode.Uri) {
     }
 
     const terminal = (<any>vscode.window).createTerminal(`Python`);
-    // Temporary workaround until a promise of terminal readiness is available:
-    // https://github.com/Tyriar/vscode-terminal-api-example/issues/2
-    setTimeout(() => {
-        terminal.sendText(`${currentPythonPath} ${filePath}`);
-    }, 1000);
+    terminal.sendText(`${currentPythonPath} ${filePath}`);
 
 }

--- a/src/client/providers/setInterpreterProvider.ts
+++ b/src/client/providers/setInterpreterProvider.ts
@@ -2,8 +2,9 @@
 import * as child_process from 'child_process';
 import * as path  from "path";
 import * as vscode from "vscode";
-import * as settings from "./../common/configSettings";
-import * as utils from "./../common/utils";
+import * as settings from "../common/configSettings";
+import { Commands } from '../common/constants';
+import * as utils from "../common/utils";
 let ncp = require("copy-paste");
 
 // where to find the Python binary within a conda env
@@ -20,7 +21,7 @@ function workspaceSettingsPath() {
 }
 
 export function activateSetInterpreterProvider() {
-    vscode.commands.registerCommand("python.setInterpreter", setInterpreter);
+    vscode.commands.registerCommand(Commands.Set_Interpreter, setInterpreter);
 }
 
 function suggestionsFromConda(): Promise<PythonPathSuggestion[]> {


### PR DESCRIPTION
This PR is a work in progress that will implement #261.

It uses the yet-unreleased [terminal extension](https://github.com/Tyriar/vscode-terminal-api-example), and so can only be tested using an Insider build.

Right now this PR adds a new `Run Python file in Terminal` command to the palette that will run the focused editor window in the terminal using the `pythonPath` interpreter. 

It includes a grim `setTimeout` workaround due to there seemingly currently not being an API for finding out when a terminal is ready for use (see https://github.com/Microsoft/vscode/issues/10918).

It also doesn't include the right-click a file menu option - @DonJayamanne I couldn't find that extension point?

#### TODO

- [x] Remove `setTimeout`/`<any>` cast when final terminal API ships
- [x] Add right-click context menu support if possible
- [ ] reuse existing terminal menu (waiting on Microsoft/vscode#10925)
- [x] restrict command to only work on Python files