### PR TITLE
Select Workspace Interpreter now can perform change itself

### DIFF
--- a/src/client/providers/setInterpreterProvider.ts
+++ b/src/client/providers/setInterpreterProvider.ts
@@ -78,11 +78,6 @@ function setPythonPath(pythonPath: string) {
     // Waiting on https://github.com/Microsoft/vscode/issues/1396
     // For now, just let the user copy this to clipboard
     const copy_msg =  "Copy to Clipboard"
-
-    // If the user already has .vscode/settings.json in the workspace
-    // open it for them
-    vscode.workspace.openTextDocument(workspaceSettingsPath())
-        .then(doc => vscode.window.showTextDocument(doc));
     
     vscode.window.showInformationMessage(pythonPath, copy_msg)
         .then(item => {
@@ -119,16 +114,5 @@ function setInterpreter() {
         vscode.window.showErrorMessage("The interpreter can only be set within a workspace (open a folder)")
         return
     }
-    vscode.workspace.openTextDocument(settingsPath)
-        .then(doc => {
-                // Great, workspace file exists. Present it for copy/pasting into...
-                vscode.window.showTextDocument(doc);
-                // ...and offer the quick-pick suggestions.
-                presentQuickPickOfSuggestedPythonPaths()
-            }, 
-            () => {
-                // The user doesn't have any workspace settings!
-                // Prompt them to create one first
-                vscode.window.showErrorMessage("No workspace settings file. First, run 'Preferences: Open Workspace Settings' to create one." )
-                })
+    vscode.commands.executeCommand('workbench.action.openWorkspaceSettings').then(presentQuickPickOfSuggestedPythonPaths)
 }


### PR DESCRIPTION
The Select Workspace Interpreter command is now able to edit `.vscode/settings.json` itself in the case where a `python.pythonPath` setting is already present. In this case, the command effects the change of the workspace interpreter without opening the `settings.json` file in an editor window, with just a subtle information message confirming the change of interpreter.

### Why only offer this if the user has already set python.pythonPath?

We can do this reliably in this case as we can have a simple robust regular expression to find a users current preference for replacing:
```javascript
 /("python\.pythonPath"\s*:\s*)"(.*)"/
``` 
If we want to insert a _new_ field into the file, we would need to basically do:
```javascript
settings = JSON.parse(settingsText)
settings["python.pythonPath"] = newPath
updateSettings(JSON.stringify(settings))
```
this would be very robust of course from a machine interpretation POV, but could change the settings file quite dramatically for the user:

1. Spacing/tabbing wouldn't be preserved
2. Key ordering wouldn't be preserved
3. Comments wouldn't be preserved 

so I think this is best left until there is an official API.