### PR TITLE
Rename launch config names for the debugger.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,7 +16,7 @@
             "preLaunchTask": "npm"
         },
         {
-            "name": "Attach",
+            "name": "Launch Extension as debugServer", // https://code.visualstudio.com/docs/extensions/example-debuggers
             "type": "node",
             "request": "launch",
             "runtimeArgs": [

--- a/src/client/.vscode/launch.json
+++ b/src/client/.vscode/launch.json
@@ -16,7 +16,7 @@
             "preLaunchTask": "npm"
         },
         {
-            "name": "Attach to python debug server",
+            "name": "Launch Extension as debugServer", // https://code.visualstudio.com/docs/extensions/example-debuggers
             "type": "node",
             "request": "launch",
             "runtimeArgs": [


### PR DESCRIPTION
I found myself quite confused first trying to run the Python debugger of this extension in developing or debugging mode, until I read the "Development Setup for mock-debug" section in the doc page "Example - Debuggers" of VSCode.

So I'm trying to rename and comment the launch config of the debugger to make them easier for new contributors to understand.
