### PR TITLE
fix #252 and #302 after vscode update to 1.5.1

### DIFF
--- a/src/client/debugger/Main.ts
+++ b/src/client/debugger/Main.ts
@@ -369,26 +369,14 @@ export class PythonDebugger extends DebugSession {
     /** converts the remote path to local path */
     protected convertDebuggerPathToClient(remotePath: string): string {
         if (this.attachArgs && this.attachArgs.localRoot && this.attachArgs.remoteRoot) {
-            let pathRelativeToSourceRoot = path.relative(this.attachArgs.remoteRoot, remotePath);
+            let path2 = path.win32;
+            if (this.attachArgs.remoteRoot.indexOf('/') != -1) {
+                path2 = path.posix;
+            }
+            let pathRelativeToSourceRoot = path2.relative(this.attachArgs.remoteRoot, remotePath);
+            // resolve from the local source root
             let clientPath = path.resolve(this.attachArgs.localRoot, pathRelativeToSourceRoot);
-            if (validatePathSync(clientPath)){
-                return clientPath;
-            }
-            else {
-                // It is possible we're dealing with cross platform debugging
-                // If so, then path.relative won't work :(
-                if (remotePath.toUpperCase().startsWith(this.attachArgs.remoteRoot.toUpperCase())) {
-                    pathRelativeToSourceRoot = remotePath.substring(this.attachArgs.remoteRoot.length).trim();
-                } else {
-                    // get the part of the path that is relative to the source root
-                    pathRelativeToSourceRoot = path.relative(this.attachArgs.remoteRoot, remotePath).trim();
-                }
-                if (pathRelativeToSourceRoot.startsWith(path.sep)){
-                    pathRelativeToSourceRoot = pathRelativeToSourceRoot.substring(1);
-                }
-                // resolve from the local source root
-                return path.resolve(this.attachArgs.localRoot, pathRelativeToSourceRoot);
-            }
+            return clientPath;
         } else {
             return remotePath;
         }
@@ -399,7 +387,11 @@ export class PythonDebugger extends DebugSession {
             // get the part of the path that is relative to the client root
             const pathRelativeToClientRoot = path.relative(this.attachArgs.localRoot, clientPath);
             // resolve from the remote source root
-            return path.resolve(this.attachArgs.remoteRoot, pathRelativeToClientRoot);
+            let path2 = path.win32;
+            if (this.attachArgs.remoteRoot.indexOf('/') != -1) {
+                path2 = path.posix;
+            }
+            return path2.resolve(this.attachArgs.remoteRoot, pathRelativeToClientRoot);
         } else {
             return clientPath;
         }


### PR DESCRIPTION
fix #252 and #302 after vscode update to 1.5.1

Remote debugging broke again after VSCode updated to 1.5.1.

Reading your first fix to #252, I understood that part of code better, I think. And I still believe that using platform specific version of `path` to tackle with remote paths should solve the problems, e.g. `path.sep`, `path.resolve`, etc. Ref: https://nodejs.org/api/path.html#path_windows_vs_posix

So I changed the logic a bit, but couldn't come up with a better name than `path2`, to avoid name conflict with `remotePath`, name of the argument.

I also removed the call to `validatePathSync()`, not seeing its effect, since I believed once `path` were platform specific, there should be no problems.

Correct me if I'm wrong. Thanks!
