### PR TITLE
Strongly type createTerminal

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "theme": "dark"
   },
   "engines": {
-    "vscode": "^1.4.0"
+    "vscode": "^1.5.0"
   },
   "categories": [
     "Languages",

--- a/src/client/providers/execInTerminalProvider.ts
+++ b/src/client/providers/execInTerminalProvider.ts
@@ -37,7 +37,7 @@ function execInTerminal(fileUri?: vscode.Uri) {
     if (filePath.indexOf(' ') > 0) {
         filePath = `"${filePath}"`;
     }
-    const terminal = (<any>vscode.window).createTerminal(`Python`);
+    const terminal = vscode.window.createTerminal(`Python`);
     terminal.sendText(`${currentPythonPath} ${filePath}`);
 
 }
@@ -54,6 +54,6 @@ function execSelectionInTerminal() {
         return;
     }
     const code = vscode.window.activeTextEditor.document.getText(new vscode.Range(selection.start, selection.end));
-    const terminal = (<any>vscode.window).createTerminal(`Python`);
+    const terminal = vscode.window.createTerminal(`Python`);
     terminal.sendText(`${currentPythonPath} -c "${code}"`);
 }

--- a/src/client/unittests/common/runner.ts
+++ b/src/client/unittests/common/runner.ts
@@ -27,7 +27,7 @@ function runTestInTerminal(file: string, args: string[], cwd: string): Promise<a
             commands.push(`cd ${cwd}`);
         }
         commands.push(`${file} ${args.join(' ')}`);
-        terminal = (<any>window).createTerminal(`Python Test Log`);
+        terminal = window.createTerminal(`Python Test Log`);
 
         return new Promise<any>((resolve) => {
             setTimeout(function () {


### PR DESCRIPTION
Now that v1.5 is stable we can strongly type the Terminal API.

![image](https://cloud.githubusercontent.com/assets/2193314/18533614/354151a0-7a99-11e6-9910-4fb858e93a58.png)
