### PR TITLE
Added setting to execute files in terminal using the file's directory…

### DIFF
--- a/package.json
+++ b/package.json
@@ -681,6 +681,11 @@
           "type": "boolean",
           "default": false,
           "description": "When executing a file in the terminal, whether to use execute in the file's directory, instead of the current open folder."
+        },
+        "python.terminal.launchArgs": {
+          "type": "array",
+          "default": [],
+          "description": "Python launch arguments to use when executing a file in the terminal."
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -675,6 +675,12 @@
           "type": "string",
           "default": "Python Test Log",
           "description": "The output window name for the unit test messages, defaults to Python output window."
+        },
+
+        "python.terminal.executeInFileDir": {
+          "type": "boolean",
+          "default": false,
+          "description": "When executing a file in the terminal, whether to use execute in the file's directory, instead of the current open folder."
         }
       }
     }

--- a/src/client/common/configSettings.ts
+++ b/src/client/common/configSettings.ts
@@ -12,6 +12,7 @@ export interface IPythonSettings {
     formatting: IFormattingSettings;
     unitTest: IUnitTestSettings;
     autoComplete: IAutoCompeteSettings;
+    terminal: ITerminalSettings;
 }
 export interface IUnitTestSettings {
     nosetestsEnabled: boolean;
@@ -66,6 +67,10 @@ export interface IFormattingSettings {
 export interface IAutoCompeteSettings {
     extraPaths: string[];
 }
+export interface ITerminalSettings {
+    executeInFileDir: boolean;
+}
+
 const systemVariables: SystemVariables = new SystemVariables();
 export class PythonSettings extends EventEmitter implements IPythonSettings {
     private static pythonSettings: PythonSettings = new PythonSettings();
@@ -135,6 +140,14 @@ export class PythonSettings extends EventEmitter implements IPythonSettings {
         this.unitTest.nosetestArgs = this.unitTest.nosetestArgs.map(arg => systemVariables.resolveAny(arg));
         this.unitTest.pyTestArgs = this.unitTest.pyTestArgs.map(arg => systemVariables.resolveAny(arg));
         this.unitTest.unittestArgs = this.unitTest.unittestArgs.map(arg => systemVariables.resolveAny(arg));
+
+        let terminalSettings = systemVariables.resolveAny(pythonSettings.get<ITerminalSettings>('terminal'));
+        if (this.terminal) {
+            Object.assign<ITerminalSettings, ITerminalSettings>(this.terminal, terminalSettings);
+        }
+        else {
+            this.terminal = terminalSettings;
+        }
     }
 
     public pythonPath: string;
@@ -143,6 +156,7 @@ export class PythonSettings extends EventEmitter implements IPythonSettings {
     public formatting: IFormattingSettings;
     public autoComplete: IAutoCompeteSettings;
     public unitTest: IUnitTestSettings;
+    public terminal: ITerminalSettings;
 }
 
 function getAbsolutePath(pathToCheck: string, rootDir: String): string {

--- a/src/client/common/configSettings.ts
+++ b/src/client/common/configSettings.ts
@@ -69,6 +69,7 @@ export interface IAutoCompeteSettings {
 }
 export interface ITerminalSettings {
     executeInFileDir: boolean;
+    launchArgs: string[];
 }
 
 const systemVariables: SystemVariables = new SystemVariables();

--- a/src/client/providers/execInTerminalProvider.ts
+++ b/src/client/providers/execInTerminalProvider.ts
@@ -48,7 +48,7 @@ function execInTerminal(fileUri?: vscode.Uri) {
     }
     const launchArgs = settings.PythonSettings.getInstance().terminal.launchArgs;
     const launchArgsString = launchArgs.length > 0 ? " ".concat(launchArgs.join(" ")) : "";
-    terminal.sendText(`${currentPythonPath} ${filePath}${launchArgsString}`);
+    terminal.sendText(`${currentPythonPath}${launchArgsString} ${filePath}`);
     terminal.show();
 }
 
@@ -67,6 +67,6 @@ function execSelectionInTerminal() {
     const terminal = vscode.window.createTerminal(`Python`);
     const launchArgs = settings.PythonSettings.getInstance().terminal.launchArgs;
     const launchArgsString = launchArgs.length > 0 ? " ".concat(launchArgs.join(" ")) : "";
-    terminal.sendText(`${currentPythonPath} -c "${code}"${launchArgsString}`);
+    terminal.sendText(`${currentPythonPath}${launchArgsString} -c "${code}"`);
     terminal.show();
 }

--- a/src/client/providers/execInTerminalProvider.ts
+++ b/src/client/providers/execInTerminalProvider.ts
@@ -2,6 +2,7 @@
 import * as vscode from 'vscode';
 import * as settings from '../common/configSettings';
 import { Commands } from '../common/constants';
+let path = require('path');
 
 export function activateExecInTerminalProvider() {
     vscode.commands.registerCommand(Commands.Exec_In_Terminal, execInTerminal);
@@ -9,7 +10,8 @@ export function activateExecInTerminalProvider() {
 }
 
 function execInTerminal(fileUri?: vscode.Uri) {
-    const currentPythonPath = settings.PythonSettings.getInstance().pythonPath;
+    let pythonSettings = settings.PythonSettings.getInstance()
+    const currentPythonPath = pythonSettings.pythonPath;
     let filePath: string;
 
     if (fileUri === undefined) {
@@ -38,8 +40,13 @@ function execInTerminal(fileUri?: vscode.Uri) {
         filePath = `"${filePath}"`;
     }
     const terminal = vscode.window.createTerminal(`Python`);
+    if (pythonSettings.terminal.executeInFileDir) {
+        let fileDirPath = path.dirname(filePath).substring(1);
+        if (fileDirPath != vscode.workspace.rootPath) {
+            terminal.sendText(`cd "${fileDirPath}"`);
+        }
+    }
     terminal.sendText(`${currentPythonPath} ${filePath}`);
-
 }
 
 function execSelectionInTerminal() {

--- a/src/client/providers/execInTerminalProvider.ts
+++ b/src/client/providers/execInTerminalProvider.ts
@@ -40,13 +40,16 @@ function execInTerminal(fileUri?: vscode.Uri) {
         filePath = `"${filePath}"`;
     }
     const terminal = vscode.window.createTerminal(`Python`);
-    if (pythonSettings.terminal.executeInFileDir) {
-        let fileDirPath = path.dirname(filePath).substring(1);
+    if (pythonSettings.terminal && pythonSettings.terminal.executeInFileDir) {
+        const fileDirPath = path.dirname(filePath).substring(1);
         if (fileDirPath != vscode.workspace.rootPath) {
             terminal.sendText(`cd "${fileDirPath}"`);
         }
     }
-    terminal.sendText(`${currentPythonPath} ${filePath}`);
+    const launchArgs = settings.PythonSettings.getInstance().terminal.launchArgs;
+    const launchArgsString = launchArgs.length > 0 ? " ".concat(launchArgs.join(" ")) : "";
+    terminal.sendText(`${currentPythonPath} ${filePath}${launchArgsString}`);
+    terminal.show();
 }
 
 function execSelectionInTerminal() {
@@ -62,5 +65,8 @@ function execSelectionInTerminal() {
     }
     const code = vscode.window.activeTextEditor.document.getText(new vscode.Range(selection.start, selection.end));
     const terminal = vscode.window.createTerminal(`Python`);
-    terminal.sendText(`${currentPythonPath} -c "${code}"`);
+    const launchArgs = settings.PythonSettings.getInstance().terminal.launchArgs;
+    const launchArgsString = launchArgs.length > 0 ? " ".concat(launchArgs.join(" ")) : "";
+    terminal.sendText(`${currentPythonPath} -c "${code}"${launchArgsString}`);
+    terminal.show();
 }

--- a/src/client/providers/execInTerminalProvider.ts
+++ b/src/client/providers/execInTerminalProvider.ts
@@ -10,7 +10,7 @@ export function activateExecInTerminalProvider() {
 }
 
 function execInTerminal(fileUri?: vscode.Uri) {
-    let pythonSettings = settings.PythonSettings.getInstance()
+    let pythonSettings = settings.PythonSettings.getInstance();
     const currentPythonPath = pythonSettings.pythonPath;
     let filePath: string;
 
@@ -42,7 +42,7 @@ function execInTerminal(fileUri?: vscode.Uri) {
     const terminal = vscode.window.createTerminal(`Python`);
     if (pythonSettings.terminal && pythonSettings.terminal.executeInFileDir) {
         const fileDirPath = path.dirname(filePath).substring(1);
-        if (fileDirPath != vscode.workspace.rootPath) {
+        if (fileDirPath !== vscode.workspace.rootPath) {
             terminal.sendText(`cd "${fileDirPath}"`);
         }
     }


### PR DESCRIPTION
… as the working directory.

Couple of caveats:

- I don't use Git or decentralized repos so this is new for me. I also don't code JavaScript or TypeScript but I'm picking this up for fun. Take it easy - I'm new and don't know that much.
- Want to go through the process on a trivial, minor setting change. To be fair, I'm actually not a big fan of this change, but I implemented it nonetheless.
- I'll be moving into more meaningful bugs/enhancements in the future (for instance, the indentation issue which I previously commented on). 

This change addresses #314 , by giving the user a setting of "python.terminal.executeInFileDir", defaulting to False, that, when set to True, will navigate to the directory of the file first, before executing the file in the terminal. 

