### PR TITLE
Changed capitalization of context menu entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
       },
       {
         "command": "python.execInTerminal",
-        "title": "Run Python file in Terminal",
+        "title": "Run Python File in Terminal",
         "category": "Python"
       },
       {


### PR DESCRIPTION
Very minor change here, just fixed the capitalization of context menu entry. No other differences vs. master branch. Lowercase looks ugly + consistent with other Visual Studio software. 

![image](https://cloud.githubusercontent.com/assets/21064086/18617134/ce6ec61e-7d96-11e6-8177-6482e3806538.png)
