### PR TITLE
Fix sys.path changes for use of bundled jedi

### DIFF
--- a/pythonFiles/completion.py
+++ b/pythonFiles/completion.py
@@ -4,7 +4,7 @@ import re
 import sys
 import json
 import traceback
-sys.path.append(os.path.dirname(__file__))
+sys.path.insert(0, os.path.dirname(__file__))
 import jedi
 # remove jedi from path after we import it so it will not be completed
 sys.path.pop(0)


### PR DESCRIPTION
The path to bundled jedi was appended to sys.path instead of prepended,
which means if user had a different jedi version installed that would be
used instead.
Also, we pop the 0'th element after the jedi import, so it it was
previously incorrect and would pop the wrong entry from sys.path.
