### PR TITLE
bugfix: fix prospector linter to not fail on unset line number.

### DIFF
--- a/src/client/linters/prospector.ts
+++ b/src/client/linters/prospector.ts
@@ -53,9 +53,10 @@ export class Linter extends baseLinter.BaseLinter {
                 let diagnostics: baseLinter.ILintMessage[] = [];
                 parsedData.messages.filter((value, index) => index <= this.pythonSettings.linting.maxNumberOfProblems).forEach(msg => {
 
-                    let sourceLine = txtDocumentLines[msg.location.line - 1];
+		    let lineNumber = msg.location.line === null || isNaN(msg.location.line) ? 1 : msg.location.line;
+		    let sourceLine = txtDocumentLines[lineNumber - 1];
                     let sourceStart = sourceLine.substring(msg.location.character);
-                    let endCol = txtDocumentLines[msg.location.line - 1].length;
+                    let endCol = txtDocumentLines[lineNumber - 1].length;
 
                     // try to get the first word from the starting position
                     let possibleProblemWords = sourceStart.match(/\w+/g);
@@ -68,7 +69,7 @@ export class Linter extends baseLinter.BaseLinter {
                         code: msg.code,
                         message: msg.message,
                         column: msg.location.character,
-                        line: msg.location.line,
+                        line: lineNumber,
                         possibleWord: possibleWord,
                         type: msg.code,
                         provider: `${this.Id} - ${msg.source}`


### PR DESCRIPTION
While using prospector linter, I encountered strange behavior. It gave this output:
```
Linting with prospector failed.
TypeError: Cannot read property 'substring' of undefined
```
Debugged the code and found out that it was crashing on this PEP8 message:

> E101: indentation contains mixed spaces and tabs  

Turns out, this particular lint message (and probably others aswell), doesn't contain line number, therefore, in `src/client/linters/prospector.ts`, this line
```
let sourceLine = txtDocumentLines[msg.location.line - 1];
```
got assigned `undefined` and the next line
```
let sourceStart = sourceLine.substring(msg.location.character);
```
crashed with error mentioned above.

This pull request fixes the issue.

