### PR TITLE
Feature/disable linting level

### DIFF
--- a/package.json
+++ b/package.json
@@ -525,7 +525,8 @@
             "Hint",
             "Error",
             "Information",
-            "Warning"
+            "Warning",
+            "Ignore"
           ]
         },
         "python.linting.pylintCategorySeverity.refactor": {
@@ -536,7 +537,9 @@
             "Hint",
             "Error",
             "Information",
-            "Warning"
+            "Warning",
+            "Ignore"
+
           ]
         },
         "python.linting.pylintCategorySeverity.warning": {
@@ -547,7 +550,9 @@
             "Hint",
             "Error",
             "Information",
-            "Warning"
+            "Warning",
+            "Ignore"
+
           ]
         },
         "python.linting.pylintCategorySeverity.error": {
@@ -558,7 +563,9 @@
             "Hint",
             "Error",
             "Information",
-            "Warning"
+            "Warning",
+            "Ignore"
+
           ]
         },
         "python.linting.pylintCategorySeverity.fatal": {
@@ -569,7 +576,9 @@
             "Hint",
             "Error",
             "Information",
-            "Warning"
+            "Warning",
+            "Ignore"
+
           ]
         },
         "python.linting.prospectorPath": {

--- a/src/client/linters/baseLinter.ts
+++ b/src/client/linters/baseLinter.ts
@@ -31,7 +31,8 @@ export enum LintMessageSeverity {
     Hint,
     Error,
     Warning,
-    Information
+    Information,
+    Ignore
 }
 
 export function matchNamedRegEx(data, regex): IRegexGroup {

--- a/src/client/linters/pylint.ts
+++ b/src/client/linters/pylint.ts
@@ -13,6 +13,8 @@ export class Linter extends baseLinter.BaseLinter {
         if (this.pythonSettings.linting.pylintCategorySeverity[category]) {
             let severityName = this.pythonSettings.linting.pylintCategorySeverity[category];
             switch (severityName) {
+                case 'Ignore':
+                    return baseLinter.LintMessageSeverity.Ignore;
                 case 'Error':
                     return baseLinter.LintMessageSeverity.Error;
                 case 'Hint':

--- a/src/client/providers/lintProvider.ts
+++ b/src/client/providers/lintProvider.ts
@@ -14,6 +14,7 @@ import * as telemetryHelper from '../common/telemetry';
 import * as telemetryContracts from '../common/telemetryContracts';
 import { LinterErrors } from '../common/constants'
 const lintSeverityToVSSeverity = new Map<linter.LintMessageSeverity, vscode.DiagnosticSeverity>();
+lintSeverityToVSSeverity.set(linter.LintMessageSeverity.Ignore, vscode.DiagnosticSeverity.Ignore)
 lintSeverityToVSSeverity.set(linter.LintMessageSeverity.Error, vscode.DiagnosticSeverity.Error)
 lintSeverityToVSSeverity.set(linter.LintMessageSeverity.Hint, vscode.DiagnosticSeverity.Hint)
 lintSeverityToVSSeverity.set(linter.LintMessageSeverity.Information, vscode.DiagnosticSeverity.Information)
@@ -154,7 +155,9 @@ export class LintProvider extends vscode.Disposable {
                                 d.code === LinterErrors.flake8.InvalidSyntax)) {
                             return;
                         }
-                        diagnostics.push(createDiagnostics(d, documentLines));
+                        if (d.severity !== linter.LintMessageSeverity.Ignore) {
+                            diagnostics.push(createDiagnostics(d, documentLines));
+                        }
                     });
 
                     // Limit the number of messages to the max value

--- a/src/test/extension.jupyter.comms.jupyterKernel.test.ts
+++ b/src/test/extension.jupyter.comms.jupyterKernel.test.ts
@@ -13,7 +13,7 @@ import { JupyterClientAdapter } from '../client/jupyter/jupyter_client/main';
 import * as mocks from './mockClasses';
 import { KernelRestartedError, KernelShutdownError } from '../client/jupyter/common/errors';
 import { createDeferred } from '../client/common/helpers';
-import { JupyterClientKernel } from '../client/jupyter/jupyter_client-kernel';
+import { JupyterClientKernel } from '../client/jupyter/jupyter_client-Kernel';
 import { KernelspecMetadata } from '../client/jupyter/contracts';
 
 suiteSetup(done => {


### PR DESCRIPTION

I have not found how to simply ignore a severity level of a linter,
so I have decide to add the feature.

Personnaly, I keep pep8 for convention but ignore what pylint returned
to me, I know that I could add a pylintrc but as we can customize a level to the
severity, "Ignore" make sense to me.

Here is my config:

```
   ...
    "python.linting.pylintEnabled": true,
    "python.linting.pylintCategorySeverity.convention": "Ignore",
    "python.linting.pylintCategorySeverity.refactor": "Information",
    "python.linting.pylintCategorySeverity.warning": "Warning",
    "python.linting.pylintCategorySeverity.error": "Error",
    "python.linting.pylintCategorySeverity.fatal": "Error",
   ...
```
I have fix an import that have nothing to do with this pull request.

I have no idea of what tests to add for that and how it is revelant.