### PR TITLE
Fixed the Jupyter Run Selection keyboard shortcut, fixed typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ For further information and details continue through to the [documentation](http
 
 ### Current Version 0.5.0
 * Remove dependency on zmq when using Jupyter or IPython (pure python solution)
-* Added a default keybinding for ```Jupyter:Run Selectiong/Line``` of ```ctrl+alt+enter```
+* Added a default keybinding for ```Jupyter:Run Selection/Line``` of ```ctrl+alt+enter```
 * Changes to update settings.json with path to python using [native API](https://github.com/DonJayamanne/pythonVSCode/commit/bce22a2b4af87eaf40669c6360eff3675280cdad)
 * Changes to use [native API](https://github.com/DonJayamanne/pythonVSCode/commit/bce22a2b4af87eaf40669c6360eff3675280cdad) for formatting when saving documents
 * Reusing existing terminal instead of creating new terminals

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "keybindings": [
       {
         "command": "jupyter.runSelectionLine",
-        "key": "ctrl+alt+enter"
+        "key": "ctrl+alt+enter",
+        "when": "editorFocus && !replaceActive && !searchViewletVisible && !findWidgetVisible"
       }
     ],
     "commands": [


### PR DESCRIPTION
In #371, I mentioned that the Jupyter shortcut conflicts with find and replace all. However, those shortcuts have conditions on them which do not conflict with Jupyter, so if we impose similar conditions of editor-focus, and no search/find dialog open, then I believe the CTRL+Alt+Enter will still work.

Also fixed a typo in the readme.