### PR TITLE
Eliminate dependency on sys module in "if main" snippet

### DIFF
--- a/snippets/python.json
+++ b/snippets/python.json
@@ -190,8 +190,7 @@
             "\t${pass}",
             "",
             "if __name__ == '__main__':",
-            "\timport sys",
-            "\tsys.exit(int(main() or 0))"
+            "\tmain()"
         ],
         "description": "Code snippet for a main function"
     },


### PR DESCRIPTION
Justification:

- Putting an import within the "if main" seems unconventional, most linters will ask you to move it to the top of the module, typically leads to one manually copying the import to the top of the module - it is no longer a self-contained snippet
- It doesn't seem that common of a convention for instance [here](https://docs.python.org/2/library/__main__.html) in the official Python docs, or [here](http://stackoverflow.com/questions/419163/what-does-if-name-main-do) from a popular question on StackOverflow
- There is a very old [blog post]
(http://www.artima.com/weblogs/viewpost.jsp?thread=4829) by Guido about this, which is similar to the current implementation, but is attempting to remedy what probably is a non-issue - one calling sys.exit() in the main() function
- For simplicity purposes, and cleanest code, I think the sys module dependency and associated exit() call should be removed