### PR TITLE
Add Formatters to category list

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "Debuggers",
     "Linters",
     "Snippets",
+    "Formatters",
     "Other"
   ],
   "activationEvents": [


### PR DESCRIPTION
The Marketplace has introduce a new category called formatters for extensions that add formatting.