### PR TITLE
Change StopOnEntry defaults to false

### DIFF
--- a/package.json
+++ b/package.json
@@ -253,7 +253,7 @@
               "stopOnEntry": {
                 "type": "boolean",
                 "description": "Automatically stop after launch.",
-                "default": true
+                "default": false
               },
               "externalConsole": {
                 "type": "boolean",
@@ -371,7 +371,7 @@
             "name": "Python",
             "type": "python",
             "request": "launch",
-            "stopOnEntry": true,
+            "stopOnEntry": false,
             "pythonPath": "${config.python.pythonPath}",
             "program": "${file}",
             "debugOptions": [
@@ -384,7 +384,7 @@
             "name": "Integrated Terminal/Console",
             "type": "python",
             "request": "launch",
-            "stopOnEntry": true,
+            "stopOnEntry": false,
             "pythonPath": "${config.python.pythonPath}",
             "program": "${file}",
             "console": "integratedTerminal",
@@ -397,7 +397,7 @@
             "name": "External Terminal/Console",
             "type": "python",
             "request": "launch",
-            "stopOnEntry": true,
+            "stopOnEntry": false,
             "pythonPath": "${config.python.pythonPath}",
             "program": "${file}",
             "console": "externalTerminal",


### PR DESCRIPTION
I think this is a more logical StopOnEntry default value for non-web applications. I left the Django and Flask settings as-is. IDEs I've used in the past do not have this behavior (PTVS mainly), and when searching for this I found a stackoverflow answered by Spyder devs who say as much as well:

http://stackoverflow.com/questions/28280308/how-do-i-debug-efficiently-with-spyder-in-python

> 
> (Spyder dev here) We're aware the debugging experience in Spyder is far from ideal. What we offer right now is very similar to the standard Python debugger, but we're working to improve things in our next major version to provide something closer to what any scientist would expect of a debugger (in short, a regular IPython console that lets you inspect and plot variables at the current breakpoint).
> 
> Now about your points:
> 
> _It's true. We're thinking to improve that so that if the user press the Run button, and there is a breakpoint present in the current file, then Spyder enters in debug mode and executes the program until the first breakpoint is met._

May want to get other users' feedback, but I think stopping only on the first breakpoint is the most logical default. If a user wanted to stop on the first line, they can always press F11 to step into, which will still maintain any breakpoints they have, but start at the first line of code.