### PR TITLE
Fix regex for matching pylint exceptions

### DIFF
--- a/src/client/linters/pylama.ts
+++ b/src/client/linters/pylama.ts
@@ -4,7 +4,7 @@ import * as baseLinter from './baseLinter';
 import {OutputChannel} from 'vscode';
 import { Product } from '../common/installer';
 
-const REGEX = '(?<file>.py):(?<line>\\d+):(?<column>\\d+): \\[(?<type>\\w+)\\] (?<code>\\w\\d+) (?<message>.*)\\r?(\\n|$)';
+const REGEX = '(?<file>.py):(?<line>\\d+):(?<column>\\d+): \\[(?<type>\\w+)\\] (?<code>\\w\\d+):? (?<message>.*)\\r?(\\n|$)';
 
 export class Linter extends baseLinter.BaseLinter {
     constructor(outputChannel: OutputChannel, workspaceRootPath: string) {


### PR DESCRIPTION
For some linters pylama adds a semicolon to the error code, but for others not. The regex thus only matched a subset of the results pylama returned. This edit should fix that