### PR TITLE
No need to define pysparkPath

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "onCommand:jupyter.execCurrentCell",
     "onCommand:jupyter.execCurrentCellAndAdvance",
     "onCommand:python.displayHelp",
-    "onCommand:python.buildWorkspaceSymbols"
+    "onCommand:python.buildWorkspaceSymbols",
+    "onCommand:python.updateSparkLibrary"
   ],
   "main": "./out/client/extension",
   "contributes": {

--- a/package.json
+++ b/package.json
@@ -419,7 +419,15 @@
             "type": "python",
             "request": "launch",
             "stopOnEntry": true,
-            "pythonPath": "${config.python.pysparkPath}",
+            "osx": {
+                "pythonPath": "${env.SPARK_HOME}/bin/spark-submit"
+            },
+            "windows": {
+                "pythonPath": "${env.SPARK_HOME}/bin/spark-submit.cmd"
+            },
+            "linux": {
+                "pythonPath": "${env.SPARK_HOME}/bin/spark-submit"
+            },
             "program": "${file}",
             "cwd": "${workspaceRoot}",
             "debugOptions": [
@@ -566,11 +574,6 @@
           "type": "string",
           "default": "python",
           "description": "Path to Python, you can use a custom version of Python by modifying this setting to include the full path."
-        },
-        "python.pysparkPath": {
-          "type": "string",
-          "default": "${env.SPARK_HOME}/bin/spark-submit",
-          "description": "Path to spark-submit executable, you can use a custom version of Spark by modifying this setting to include the full path."
         },
         "python.jediPath": {
           "type": "string",

--- a/src/client/providers/updateSparkLibraryProvider.ts
+++ b/src/client/providers/updateSparkLibraryProvider.ts
@@ -19,16 +19,6 @@ function updateSparkLibrary() {
     }, reason => {
         vscode.window.showErrorMessage(`Failed to update ${extraLibPath}. Error: ${reason.message}`);
         console.error(reason);
-    });
-    if (IS_WINDOWS) {        
-        const pysparkPath = 'pysparkPath';
-        console.log('Overriding ' + pysparkPath);
-        pythonConfig.update(pysparkPath, path.join(sparkHomePath, 'bin', 'spark-submit.cmd')).then(() => {
-        //Done
-        }, reason => {
-            vscode.window.showErrorMessage(`Failed to update ${pysparkPath}. Error: ${reason.message}`);
-            console.error(reason);
-        });
-    }
+    });    
     vscode.window.showInformationMessage(`Make sure you have SPARK_HOME environment variable set to the root path of the local spark installation!`);
 }


### PR DESCRIPTION
Based on Don's suggestion, environment specific pythonPath can be
defined.