### PR TITLE
Fix undefined error when debugging modules

### DIFF
--- a/src/client/debugger/Main.ts
+++ b/src/client/debugger/Main.ts
@@ -188,7 +188,7 @@ export class PythonDebugger extends DebugSession {
         }
         else {
             // When using modules ensure the cwd has been provided
-            if (typeof args.cwd !== 'string' || args.cwd.length === 0 || this.launchArgs.cwd === 'null') {
+            if (typeof args.cwd !== 'string' || args.cwd.length === 0 || (this.launchArgs && this.launchArgs.cwd === 'null')) {
                 return this.sendErrorResponse(response, 2001, `'cwd' in 'launch.json' needs to point to the working directory`);
             }
         }


### PR DESCRIPTION
Fixes an issue where launching a debug session with modules results in the error "Cannot read property 'cwd' of undefined".

```json
{
    "version": "0.2.0",
    "configurations": [
        {
            "name": "Python Module",
            "type": "python",
            "request": "launch",
            "stopOnEntry": true,
            "pythonPath": "${config.python.pythonPath}",
            "module": "module.name",
            "cwd": "${workspaceRoot}",
            "console": "integratedTerminal",
            "debugOptions": [
                "WaitOnAbnormalExit",
                "WaitOnNormalExit"
            ]
        }
   ]
}
```

```
messageService.ts:126 TypeError: Cannot read property 'cwd' of undefined
    at PythonDebugger.launchRequest (/Users/alex/.vscode/extensions/donjayamanne.python-0.5.5/out/client/debugger/Main.js:152:89)
    at PythonDebugger.DebugSession.dispatchRequest (/Users/alex/.vscode/extensions/donjayamanne.python-0.5.5/node_modules/vscode-debugadapter/lib/debugSession.js:361:22)
    at PythonDebugger.ProtocolServer._handleData (/Users/alex/.vscode/extensions/donjayamanne.python-0.5.5/node_modules/vscode-debugadapter/lib/protocol.js:104:38)
    at Socket.<anonymous> (/Users/alex/.vscode/extensions/donjayamanne.python-0.5.5/node_modules/vscode-debugadapter/lib/protocol.js:24:60)
    at emitOne (events.js:96:13)
    at Socket.emit (events.js:188:7)
    at readableAddChunk (_stream_readable.js:176:18)
    at Socket.Readable.push (_stream_readable.js:134:10)
    at Pipe.onread (net.js:543:20): Error: TypeError: Cannot read property 'cwd' of undefined
    at PythonDebugger.launchRequest (/Users/alex/.vscode/extensions/donjayamanne.python-0.5.5/out/client/debugger/Main.js:152:89)
    at PythonDebugger.DebugSession.dispatchRequest (/Users/alex/.vscode/extensions/donjayamanne.python-0.5.5/node_modules/vscode-debugadapter/lib/debugSession.js:361:22)
...
```