### PR TITLE
Fix type annotations and make tests pass

### DIFF
--- a/src/client/jupyter/jupyter_client/jupyterSocketClient.ts
+++ b/src/client/jupyter/jupyter_client/jupyterSocketClient.ts
@@ -187,7 +187,7 @@ export class JupyterSocketClient extends SocketCallbackHandler {
         def.resolve();
     }
     public ping(message: string) {
-        const [def, id] = this.createId<string[]>();
+        const [def, id] = this.createId<string>();
         this.SendRawCommand(Commands.PingBytes);
         this.stream.WriteString(id);
         this.stream.WriteString(message);

--- a/src/client/jupyter/jupyter_client/main.ts
+++ b/src/client/jupyter/jupyter_client/main.ts
@@ -101,7 +101,7 @@ export class JupyterClientAdapter extends EventEmitter implements IJupyterClient
                     // Ok everything has started, now test ping
                     const msg1 = 'Hello world from Type Script - Функция проверки ИНН и КПП - 长城!1';
                     const msg2 = 'Hello world from Type Script - Функция проверки ИНН и КПП - 长城!2';
-                    Promise.all<string>([this.ipythonAdapter.ping(msg1), this.ipythonAdapter.ping(msg2)]).then(msgs => {
+                    Promise.all<string, string>([this.ipythonAdapter.ping(msg1), this.ipythonAdapter.ping(msg2)]).then(msgs => {
                         if (msgs.indexOf(msg1) === -1 || msgs.indexOf(msg2) === -1) {
                             def.reject('msg1 or msg2 not returned');
                         }

--- a/src/client/jupyter/kernel-manager.ts
+++ b/src/client/jupyter/kernel-manager.ts
@@ -88,16 +88,16 @@ export class KernelManagerImpl extends EventEmitter {
         throw new Error('Start Existing Kernel not implemented');
     }
 
-    public startKernel(kernelSpec: KernelspecMetadata, language: string): Promise<Kernel> {
+    public async startKernel(kernelSpec: KernelspecMetadata, language: string): Promise<Kernel> {
         this.destroyRunningKernelFor(language);
-        return this.jupyterClient.startKernel(kernelSpec).then((kernelInfo: [string, any, string]) => {
-            const kernelUUID = kernelInfo[0];
-            const config = kernelInfo[1];
-            const connectionFile = kernelInfo[2];
-            const kernel = new JupyterClientKernel(kernelSpec, language, config, connectionFile, kernelUUID, this.jupyterClient);
-            this.setRunningKernelFor(language, kernel);
-            return this.executeStartupCode(kernel).then(() => kernel);
-        });
+        const kernelInfo = await this.jupyterClient.startKernel(kernelSpec);
+        const kernelUUID = kernelInfo[0];
+        const config = kernelInfo[1];
+        const connectionFile = kernelInfo[2];
+        const kernel = new JupyterClientKernel(kernelSpec, language, config, connectionFile, kernelUUID, this.jupyterClient);
+        this.setRunningKernelFor(language, kernel);
+        await this.executeStartupCode(kernel);
+        return kernel;
     }
 
     private executeStartupCode(kernel: Kernel): Promise<any> {

--- a/src/client/providers/definitionProvider.ts
+++ b/src/client/providers/definitionProvider.ts
@@ -25,10 +25,10 @@ export class PythonDefinitionProvider implements vscode.DefinitionProvider {
     public provideDefinition(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): Thenable<vscode.Definition> {
         var filename = document.fileName;
         if (document.lineAt(position.line).text.match(/^\s*\/\//)) {
-            return Promise.resolve();
+            return Promise.resolve(null);
         }
         if (position.character <= 0) {
-            return Promise.resolve();
+            return Promise.resolve(null);
         }
 
         var range = document.getWordRangeAtPosition(position);

--- a/src/client/providers/hoverProvider.ts
+++ b/src/client/providers/hoverProvider.ts
@@ -14,15 +14,15 @@ export class PythonHoverProvider implements vscode.HoverProvider {
     public provideHover(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): Thenable<vscode.Hover> {
         var filename = document.fileName;
         if (document.lineAt(position.line).text.match(/^\s*\/\//)) {
-            return Promise.resolve();
+            return Promise.resolve(null);
         }
         if (position.character <= 0) {
-            return Promise.resolve();
+            return Promise.resolve(null);
         }
 
         var range = document.getWordRangeAtPosition(position);
         if (!range || range.isEmpty) {
-            return Promise.resolve();
+            return Promise.resolve(null);
         }
         var columnIndex = range.start.character < range.end.character ? range.start.character + 2 : range.end.character;
         var cmd: proxy.ICommand<proxy.ICompletionResult> = {

--- a/src/client/providers/referenceProvider.ts
+++ b/src/client/providers/referenceProvider.ts
@@ -34,10 +34,10 @@ export class PythonReferenceProvider implements vscode.ReferenceProvider {
     public provideReferences(document: vscode.TextDocument, position: vscode.Position, context: vscode.ReferenceContext, token: vscode.CancellationToken): Thenable<vscode.Location[]> {
         var filename = document.fileName;
         if (document.lineAt(position.line).text.match(/^\s*\/\//)) {
-            return Promise.resolve();
+            return Promise.resolve(null);
         }
         if (position.character <= 0) {
-            return Promise.resolve();
+            return Promise.resolve(null);
         }
 
         var range = document.getWordRangeAtPosition(position);

--- a/src/test/extension.autocomplete.test.ts
+++ b/src/test/extension.autocomplete.test.ts
@@ -48,8 +48,8 @@ suite('Autocomplete', () => {
             assert(vscode.window.activeTextEditor, 'No active editor');
             textEditor = editor;
             const position = new vscode.Position(3, 10);
-            return vscode.commands.executeCommand('vscode.executeCompletionItemProvider', textDocument.uri, position);
-        }).then((list: { isIncomplete: boolean, items: vscode.CompletionItem[] }) => {
+            return vscode.commands.executeCommand<vscode.CompletionList>('vscode.executeCompletionItemProvider', textDocument.uri, position);
+        }).then(list => {
             assert.notEqual(list.items.filter(item => item.label === 'api_version').length, 0, 'api_version not found');
             assert.notEqual(list.items.filter(item => item.label === 'argv').length, 0, 'argv not found');
             assert.notEqual(list.items.filter(item => item.label === 'prefix').length, 0, 'prefix not found');
@@ -66,8 +66,8 @@ suite('Autocomplete', () => {
             assert(vscode.window.activeTextEditor, 'No active editor');
             textEditor = editor;
             const position = new vscode.Position(30, 4);
-            return vscode.commands.executeCommand('vscode.executeCompletionItemProvider', textDocument.uri, position);
-        }).then((list: { isIncomplete: boolean, items: vscode.CompletionItem[] }) => {
+            return vscode.commands.executeCommand<vscode.CompletionList>('vscode.executeCompletionItemProvider', textDocument.uri, position);
+        }).then(list => {
             assert.notEqual(list.items.filter(item => item.label === 'method1').length, 0, 'method1 not found');
             assert.notEqual(list.items.filter(item => item.label === 'method2').length, 0, 'method2 not found');
         }).then(done, done);
@@ -83,8 +83,8 @@ suite('Autocomplete', () => {
             assert(vscode.window.activeTextEditor, 'No active editor');
             textEditor = editor;
             const position = new vscode.Position(25, 4);
-            return vscode.commands.executeCommand('vscode.executeCompletionItemProvider', textDocument.uri, position);
-        }).then((list: { isIncomplete: boolean, items: vscode.CompletionItem[] }) => {
+            return vscode.commands.executeCommand<vscode.CompletionList>('vscode.executeCompletionItemProvider', textDocument.uri, position);
+        }).then(list => {
             assert.equal(list.items.filter(item => item.label === 'bar').length, 1, 'bar not found');
             const documentation = `说明 - keep this line, it works${EOL}delete following line, it works${EOL}如果存在需要等待审批或正在执行的任务，将不刷新页面`;
             assert.equal(list.items.filter(item => item.label === 'bar')[0].documentation, documentation, 'unicode documentation is incorrect');
@@ -101,8 +101,8 @@ suite('Autocomplete', () => {
             assert(vscode.window.activeTextEditor, 'No active editor');
             textEditor = editor;
             const position = new vscode.Position(1, 5);
-            return vscode.commands.executeCommand('vscode.executeCompletionItemProvider', textDocument.uri, position);
-        }).then((list: { isIncomplete: boolean, items: vscode.CompletionItem[] }) => {
+            return vscode.commands.executeCommand<vscode.CompletionList>('vscode.executeCompletionItemProvider', textDocument.uri, position);
+        }).then(list => {
             assert.equal(list.items.filter(item => item.label === 'Foo').length, 1, 'Foo not found');
             assert.equal(list.items.filter(item => item.label === 'Foo')[0].documentation, '说明', 'Foo unicode documentation is incorrect');
 
@@ -138,8 +138,8 @@ suite('Code Definition', () => {
             assert(vscode.window.activeTextEditor, 'No active editor');
             textEditor = editor;
             const position = new vscode.Position(30, 5);
-            return vscode.commands.executeCommand('vscode.executeDefinitionProvider', textDocument.uri, position);
-        }).then((def: [{ range: vscode.Range, uri: vscode.Uri }]) => {
+            return vscode.commands.executeCommand<vscode.Location[]>('vscode.executeDefinitionProvider', textDocument.uri, position);
+        }).then(def => {
             assert.equal(def.length, 1, 'Definition lenght is incorrect');
             assert.equal(`${def[0].range.start.line},${def[0].range.start.character}`, '17,8', 'Start position is incorrect');
             assert.equal(`${def[0].range.end.line},${def[0].range.end.character}`, '17,8', 'End position is incorrect');
@@ -156,8 +156,8 @@ suite('Code Definition', () => {
             assert(vscode.window.activeTextEditor, 'No active editor');
             textEditor = editor;
             const position = new vscode.Position(1, 5);
-            return vscode.commands.executeCommand('vscode.executeDefinitionProvider', textDocument.uri, position);
-        }).then((def: [{ range: vscode.Range, uri: vscode.Uri }]) => {
+            return vscode.commands.executeCommand<vscode.Location[]>('vscode.executeDefinitionProvider', textDocument.uri, position);
+        }).then(def => {
             assert.equal(def.length, 1, 'Definition lenght is incorrect');
             assert.equal(`${def[0].range.start.line},${def[0].range.start.character}`, '0,6', 'Start position is incorrect');
             assert.equal(`${def[0].range.end.line},${def[0].range.end.character}`, '0,6', 'End position is incorrect');
@@ -175,8 +175,8 @@ suite('Code Definition', () => {
             assert(vscode.window.activeTextEditor, 'No active editor');
             textEditor = editor;
             const position = new vscode.Position(25, 6);
-            return vscode.commands.executeCommand('vscode.executeDefinitionProvider', textDocument.uri, position);
-        }).then((def: [{ range: vscode.Range, uri: vscode.Uri }]) => {
+            return vscode.commands.executeCommand<vscode.Location[]>('vscode.executeDefinitionProvider', textDocument.uri, position);
+        }).then(def => {
             assert.equal(def.length, 1, 'Definition lenght is incorrect');
             assert.equal(`${def[0].range.start.line},${def[0].range.start.character}`, '10,8', 'Start position is incorrect');
             assert.equal(`${def[0].range.end.line},${def[0].range.end.character}`, '10,8', 'End position is incorrect');
@@ -194,8 +194,8 @@ suite('Code Definition', () => {
             assert(vscode.window.activeTextEditor, 'No active editor');
             textEditor = editor;
             const position = new vscode.Position(1, 11);
-            return vscode.commands.executeCommand('vscode.executeDefinitionProvider', textDocument.uri, position);
-        }).then((def: [{ range: vscode.Range, uri: vscode.Uri }]) => {
+            return vscode.commands.executeCommand<vscode.Location[]>('vscode.executeDefinitionProvider', textDocument.uri, position);
+        }).then(def => {
             assert.equal(def.length, 1, 'Definition lenght is incorrect');
             assert.equal(`${def[0].range.start.line},${def[0].range.start.character}`, '18,4', 'Start position is incorrect');
             assert.equal(`${def[0].range.end.line},${def[0].range.end.character}`, '18,4', 'End position is incorrect');
@@ -229,13 +229,13 @@ suite('Hover Definition', () => {
             assert(vscode.window.activeTextEditor, 'No active editor');
             textEditor = editor;
             const position = new vscode.Position(30, 5);
-            return vscode.commands.executeCommand('vscode.executeHoverProvider', textDocument.uri, position);
-        }).then((def: [{ range: vscode.Range, contents: { language: string, value: string }[] }]) => {
+            return vscode.commands.executeCommand<vscode.Hover[]>('vscode.executeHoverProvider', textDocument.uri, position);
+        }).then(def => {
             assert.equal(def.length, 1, 'Definition lenght is incorrect');
             assert.equal(`${def[0].range.start.line},${def[0].range.start.character}`, '30,4', 'Start position is incorrect');
             assert.equal(`${def[0].range.end.line},${def[0].range.end.character}`, '30,11', 'End position is incorrect');
             assert.equal(def[0].contents.length, 2, 'Invalid content items');
-            assert.equal(def[0].contents[0].value, 'def method1(self)', 'function signature incorrect');
+            assert.equal(def[0].contents[0]['value'], 'def method1(self)', 'function signature incorrect');
             assert.equal(def[0].contents[1], `This is method1`, 'Invalid conents');
         }).then(done, done);
     });
@@ -250,12 +250,12 @@ suite('Hover Definition', () => {
             assert(vscode.window.activeTextEditor, 'No active editor');
             textEditor = editor;
             const position = new vscode.Position(1, 12);
-            return vscode.commands.executeCommand('vscode.executeHoverProvider', textDocument.uri, position);
-        }).then((def: [{ range: vscode.Range, contents: { language: string, value: string }[] }]) => {
+            return vscode.commands.executeCommand<vscode.Hover[]>('vscode.executeHoverProvider', textDocument.uri, position);
+        }).then(def => {
             assert.equal(def.length, 1, 'Definition lenght is incorrect');
             assert.equal(`${def[0].range.start.line},${def[0].range.start.character}`, '1,9', 'Start position is incorrect');
             assert.equal(`${def[0].range.end.line},${def[0].range.end.character}`, '1,12', 'End position is incorrect');
-            assert.equal(def[0].contents[0].value, 'def fun()', 'function signature incorrect');
+            assert.equal(def[0].contents[0]['value'], 'def fun()', 'function signature incorrect');
             assert.equal(def[0].contents[1], `This is fun`, 'Invalid conents');
         }).then(done, done);
     });
@@ -270,12 +270,12 @@ suite('Hover Definition', () => {
             assert(vscode.window.activeTextEditor, 'No active editor');
             textEditor = editor;
             const position = new vscode.Position(25, 6);
-            return vscode.commands.executeCommand('vscode.executeHoverProvider', textDocument.uri, position);
-        }).then((def: [{ range: vscode.Range, contents: { language: string, value: string }[] }]) => {
+            return vscode.commands.executeCommand<vscode.Hover[]>('vscode.executeHoverProvider', textDocument.uri, position);
+        }).then(def => {
             assert.equal(def.length, 1, 'Definition lenght is incorrect');
             assert.equal(`${def[0].range.start.line},${def[0].range.start.character}`, '25,4', 'Start position is incorrect');
             assert.equal(`${def[0].range.end.line},${def[0].range.end.character}`, '25,7', 'End position is incorrect');
-            assert.equal(def[0].contents[0].value, 'def bar()', 'function signature incorrect');
+            assert.equal(def[0].contents[0]['value'], 'def bar()', 'function signature incorrect');
             const documentation = `说明 - keep this line, it works${EOL}delete following line, it works${EOL}如果存在需要等待审批或正在执行的任务，将不刷新页面`;
             assert.equal(def[0].contents[1], documentation, 'Invalid conents');
         }).then(done, done);
@@ -291,12 +291,12 @@ suite('Hover Definition', () => {
             assert(vscode.window.activeTextEditor, 'No active editor');
             textEditor = editor;
             const position = new vscode.Position(1, 11);
-            return vscode.commands.executeCommand('vscode.executeHoverProvider', textDocument.uri, position);
-        }).then((def: [{ range: vscode.Range, contents: { language: string, value: string }[] }]) => {
+            return vscode.commands.executeCommand<vscode.Hover[]>('vscode.executeHoverProvider', textDocument.uri, position);
+        }).then(def => {
             assert.equal(def.length, 1, 'Definition lenght is incorrect');
             assert.equal(`${def[0].range.start.line},${def[0].range.start.character}`, '1,5', 'Start position is incorrect');
             assert.equal(`${def[0].range.end.line},${def[0].range.end.character}`, '1,16', 'End position is incorrect');
-            assert.equal(def[0].contents[0].value, 'def showMessage()', 'Invalid content items');
+            assert.equal(def[0].contents[0]['value'], 'def showMessage()', 'Invalid content items');
             const documentation = `Кюм ут жэмпэр пошжим льаборэж, коммюны янтэрэсщэт нам ед, декта игнота ныморэ жят эи. ${EOL}Шэа декам экшырки эи, эи зыд эррэм докэндё, векж факэтэ пэрчыквюэрёж ку.`;
             assert.equal(def[0].contents[1], documentation, 'Invalid conents');
         }).then(done, done);
@@ -312,8 +312,8 @@ suite('Hover Definition', () => {
             assert(vscode.window.activeTextEditor, 'No active editor');
             textEditor = editor;
             const position = new vscode.Position(5, 1);
-            return vscode.commands.executeCommand('vscode.executeHoverProvider', textDocument.uri, position);
-        }).then((def: [{ range: vscode.Range, contents: { language: string, value: string }[] }]) => {
+            return vscode.commands.executeCommand<vscode.Hover[]>('vscode.executeHoverProvider', textDocument.uri, position);
+        }).then(def => {
             assert.equal(def.length, 0, 'Definition lenght is incorrect');
         }).then(done, done);
     });
@@ -328,8 +328,8 @@ suite('Hover Definition', () => {
             assert(vscode.window.activeTextEditor, 'No active editor');
             textEditor = editor;
             const position = new vscode.Position(3, 1);
-            return vscode.commands.executeCommand('vscode.executeHoverProvider', textDocument.uri, position);
-        }).then((def: [{ range: vscode.Range, contents: { language: string, value: string }[] }]) => {
+            return vscode.commands.executeCommand<vscode.Hover[]>('vscode.executeHoverProvider', textDocument.uri, position);
+        }).then(def => {
             assert.equal(def.length, 0, 'Definition lenght is incorrect');
         }).then(done, done);
     });
@@ -344,12 +344,12 @@ suite('Hover Definition', () => {
             assert(vscode.window.activeTextEditor, 'No active editor');
             textEditor = editor;
             const position = new vscode.Position(11, 15);
-            return vscode.commands.executeCommand('vscode.executeHoverProvider', textDocument.uri, position);
-        }).then((def: [{ range: vscode.Range, contents: { language: string, value: string }[] }]) => {
+            return vscode.commands.executeCommand<vscode.Hover[]>('vscode.executeHoverProvider', textDocument.uri, position);
+        }).then(def => {
             assert.equal(def.length, 1, 'Definition lenght is incorrect');
             assert.equal(`${def[0].range.start.line},${def[0].range.start.character}`, '11,12', 'Start position is incorrect');
             assert.equal(`${def[0].range.end.line},${def[0].range.end.character}`, '11,18', 'End position is incorrect');
-            assert.equal(def[0].contents[0].value, 'class Random(self, x=None)', 'Invalid content items');
+            assert.equal(def[0].contents[0]['value'], 'class Random(self, x=None)', 'Invalid content items');
             const documentation = `Random number generator base class used by bound module functions.${EOL}${EOL}` +
                 `Used to instantiate instances of Random to get generators that don't${EOL}` +
                 `share state.${EOL}${EOL}` +
@@ -373,12 +373,12 @@ suite('Hover Definition', () => {
             assert(vscode.window.activeTextEditor, 'No active editor');
             textEditor = editor;
             const position = new vscode.Position(12, 10);
-            return vscode.commands.executeCommand('vscode.executeHoverProvider', textDocument.uri, position);
-        }).then((def: [{ range: vscode.Range, contents: { language: string, value: string }[] }]) => {
+            return vscode.commands.executeCommand<vscode.Hover[]>('vscode.executeHoverProvider', textDocument.uri, position);
+        }).then(def => {
             assert.equal(def.length, 1, 'Definition lenght is incorrect');
             assert.equal(`${def[0].range.start.line},${def[0].range.start.character}`, '12,5', 'Start position is incorrect');
             assert.equal(`${def[0].range.end.line},${def[0].range.end.character}`, '12,12', 'End position is incorrect');
-            assert.equal(def[0].contents[0].value, 'def randint(self, a, b)', 'Invalid content items');
+            assert.equal(def[0].contents[0]['value'], 'def randint(self, a, b)', 'Invalid content items');
             const documentation = `Return random integer in range [a, b], including both end points.`;
             assert.equal(def[0].contents[1], documentation, 'Invalid conents');
         }).then(done, done);
@@ -394,12 +394,12 @@ suite('Hover Definition', () => {
             assert(vscode.window.activeTextEditor, 'No active editor');
             textEditor = editor;
             const position = new vscode.Position(8, 14);
-            return vscode.commands.executeCommand('vscode.executeHoverProvider', textDocument.uri, position);
-        }).then((def: [{ range: vscode.Range, contents: { language: string, value: string }[] }]) => {
+            return vscode.commands.executeCommand<vscode.Hover[]>('vscode.executeHoverProvider', textDocument.uri, position);
+        }).then(def => {
             assert.equal(def.length, 1, 'Definition lenght is incorrect');
             assert.equal(`${def[0].range.start.line},${def[0].range.start.character}`, '8,11', 'Start position is incorrect');
             assert.equal(`${def[0].range.end.line},${def[0].range.end.character}`, '8,15', 'End position is incorrect');
-            assert.equal(def[0].contents[0].value, 'def acos(x)', 'Invalid content items');
+            assert.equal(def[0].contents[0]['value'], 'def acos(x)', 'Invalid content items');
             const documentation = `Return the arc cosine (measured in radians) of x.`;
             assert.equal(def[0].contents[1], documentation, 'Invalid conents');
         }).then(done, done);
@@ -415,13 +415,13 @@ suite('Hover Definition', () => {
             assert(vscode.window.activeTextEditor, 'No active editor');
             textEditor = editor;
             const position = new vscode.Position(14, 14);
-            return vscode.commands.executeCommand('vscode.executeHoverProvider', textDocument.uri, position);
-        }).then((def: [{ range: vscode.Range, contents: { language: string, value: string }[] }]) => {
+            return vscode.commands.executeCommand<vscode.Hover[]>('vscode.executeHoverProvider', textDocument.uri, position);
+        }).then(def => {
             assert.equal(def.length, 1, 'Definition lenght is incorrect');
             assert.equal(`${def[0].range.start.line},${def[0].range.start.character}`, '14,9', 'Start position is incorrect');
             assert.equal(`${def[0].range.end.line},${def[0].range.end.character}`, '14,15', 'End position is incorrect');
             const signature = `class Thread(self, group=None, target=None, name=None,${EOL}args=(), kwargs=None, verbose=None)`;
-            assert.equal(def[0].contents[0].value, signature, 'Invalid content items');
+            assert.equal(def[0].contents[0]['value'], signature, 'Invalid content items');
             const documentation = `A class that represents a thread of control.${EOL}${EOL}This class can be safely subclassed in a limited fashion.`;
             assert.equal(def[0].contents[1], documentation, 'Invalid conents');
         }).then(done, done);


### PR DESCRIPTION
This fixes type checks and makes `tsc` happy.

I've rewritten two functions to use `async`/`await` as I feel it makes them more readable.