### PR TITLE
Show symbol type on hover

### DIFF
--- a/src/client/providers/completionProvider.ts
+++ b/src/client/providers/completionProvider.ts
@@ -10,7 +10,7 @@ import { PythonSettings } from '../common/configSettings';
 const pythonSettings = PythonSettings.getInstance();
 
 export class PythonCompletionItemProvider implements vscode.CompletionItemProvider {
-    private jediProxyHandler: proxy.JediProxyHandler<proxy.ICompletionResult, vscode.CompletionItem[]>;
+    private jediProxyHandler: proxy.JediProxyHandler<proxy.ICompletionResult>;
 
     public constructor(context: vscode.ExtensionContext, jediProxy: proxy.JediProxy = null) {
         this.jediProxyHandler = new proxy.JediProxyHandler(context, jediProxy);

--- a/src/client/providers/definitionProvider.ts
+++ b/src/client/providers/definitionProvider.ts
@@ -5,7 +5,7 @@ import * as proxy from './jediProxy';
 import * as telemetryContracts from "../common/telemetryContracts";
 
 export class PythonDefinitionProvider implements vscode.DefinitionProvider {
-    private jediProxyHandler: proxy.JediProxyHandler<proxy.IDefinitionResult, vscode.Definition>;
+    private jediProxyHandler: proxy.JediProxyHandler<proxy.IDefinitionResult>;
     public get JediProxy(): proxy.JediProxy {
         return this.jediProxyHandler.JediProxy;
     }

--- a/src/client/providers/hoverProvider.ts
+++ b/src/client/providers/hoverProvider.ts
@@ -3,58 +3,65 @@
 import * as vscode from 'vscode';
 import * as proxy from './jediProxy';
 import * as telemetryContracts from "../common/telemetryContracts";
-import { extractHoverInfo} from './jediHelpers';
 
 export class PythonHoverProvider implements vscode.HoverProvider {
-    private jediProxyHandler: proxy.JediProxyHandler<proxy.ICompletionResult, vscode.Hover>;
+    private jediProxyHandler: proxy.JediProxyHandler<proxy.IHoverResult>;
 
     public constructor(context: vscode.ExtensionContext, jediProxy: proxy.JediProxy = null) {
         this.jediProxyHandler = new proxy.JediProxyHandler(context, jediProxy);
     }
-    public provideHover(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): Thenable<vscode.Hover> {
+    private static parseData(data: proxy.IHoverResult): vscode.Hover {
+        let results = [];
+        data.items.forEach(item => {
+            let { description, signature } = item;
+            switch (item.kind) {
+                case vscode.SymbolKind.Constructor:
+                case vscode.SymbolKind.Function:
+                case vscode.SymbolKind.Method: {
+                    signature = 'def ' + signature;
+                    break;
+                }
+                case vscode.SymbolKind.Class: {
+                    signature = 'class ' + signature;
+                    break;
+                }
+            }
+            results.push({language: 'python', value: signature});
+            if (item.description) {
+                results.push(description);
+            }
+        });
+        return new vscode.Hover(results);
+    }
+    public async provideHover(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): Promise<vscode.Hover> {
         var filename = document.fileName;
         if (document.lineAt(position.line).text.match(/^\s*\/\//)) {
-            return Promise.resolve(null);
+            return null;
         }
         if (position.character <= 0) {
-            return Promise.resolve(null);
+            return null;
         }
 
         var range = document.getWordRangeAtPosition(position);
         if (!range || range.isEmpty) {
-            return Promise.resolve(null);
+            return null;
         }
-        var columnIndex = range.start.character < range.end.character ? range.start.character + 2 : range.end.character;
-        var cmd: proxy.ICommand<proxy.ICompletionResult> = {
-            command: proxy.CommandType.Completions,
+
+        var cmd: proxy.ICommand<proxy.IDefinitionResult> = {
+            command: proxy.CommandType.Hover,
             fileName: filename,
-            columnIndex: columnIndex,
+            columnIndex: range.end.character,
             lineIndex: position.line
         };
         if (document.isDirty) {
             cmd.source = document.getText();
         }
 
-        return this.jediProxyHandler.sendCommand(cmd, token).then(data => {
-            if (!data || !Array.isArray(data.items) || data.items.length === 0) {
-                return;
-            }
-            // Find the right items
-            const wordUnderCursor = document.getText(range);
-            const completionItem = data.items.filter(item => item.text === wordUnderCursor);
-            if (completionItem.length === 0) {
-                return;
-            }
-            var definition = completionItem[0];
-            var txt = definition.description || definition.text;
-            if (typeof txt !== 'string' || txt.length === 0) {
-                return;
-            }
-            if (wordUnderCursor === txt) {
-                return;
-            }
+        const data = await this.jediProxyHandler.sendCommand(cmd, token);
+        if (!data || !data.items.length) {
+            return;
+        }
 
-            return extractHoverInfo(definition);
-        });
+        return PythonHoverProvider.parseData(data);
     }
 }

--- a/src/client/providers/jediHelpers.ts
+++ b/src/client/providers/jediHelpers.ts
@@ -47,12 +47,3 @@ export function extractSignatureAndDocumentation(definition: proxy.IAutoComplete
     }
     return [signature, lines.join(EOL).trim().replace(/^\s+|\s+$/g, '').trim()];
 }
-
-export function extractHoverInfo(definition: proxy.IAutoCompleteItem): vscode.Hover {
-    const parts = extractSignatureAndDocumentation(definition, true);
-    const hoverInfo: vscode.MarkedString[] = parts[0].length === 0 ? [] : [{ language: 'python', value: parts[0] }];
-    if (parts[1].length > 0) {
-        hoverInfo.push(parts[1]);
-    }
-    return new vscode.Hover(hoverInfo);
-}

--- a/src/client/providers/referenceProvider.ts
+++ b/src/client/providers/referenceProvider.ts
@@ -6,7 +6,7 @@ import * as telemetryContracts from "../common/telemetryContracts";
 
 
 export class PythonReferenceProvider implements vscode.ReferenceProvider {
-    private jediProxyHandler: proxy.JediProxyHandler<proxy.IReferenceResult, vscode.Location[]>;
+    private jediProxyHandler: proxy.JediProxyHandler<proxy.IReferenceResult>;
 
     public constructor(context: vscode.ExtensionContext, jediProxy: proxy.JediProxy = null) {
         this.jediProxyHandler = new proxy.JediProxyHandler(context, jediProxy);

--- a/src/client/providers/signatureProvider.ts
+++ b/src/client/providers/signatureProvider.ts
@@ -44,7 +44,7 @@ function extractParamDocString(paramName: string, docString: string): string {
     return paramDocString.trim();
 }
 export class PythonSignatureProvider implements vscode.SignatureHelpProvider {
-    private jediProxyHandler: proxy.JediProxyHandler<proxy.IArgumentsResult, vscode.SignatureHelp>;
+    private jediProxyHandler: proxy.JediProxyHandler<proxy.IArgumentsResult>;
 
     public constructor(context: vscode.ExtensionContext, jediProxy: proxy.JediProxy = null) {
         this.jediProxyHandler = new proxy.JediProxyHandler(context, jediProxy);

--- a/src/client/providers/symbolProvider.ts
+++ b/src/client/providers/symbolProvider.ts
@@ -5,7 +5,7 @@ import * as proxy from './jediProxy';
 import * as telemetryContracts from "../common/telemetryContracts";
 
 export class PythonSymbolProvider implements vscode.DocumentSymbolProvider {
-    private jediProxyHandler: proxy.JediProxyHandler<proxy.ISymbolResult, vscode.SymbolInformation[]>;
+    private jediProxyHandler: proxy.JediProxyHandler<proxy.ISymbolResult>;
 
     public constructor(context: vscode.ExtensionContext, jediProxy: proxy.JediProxy = null) {
         this.jediProxyHandler = new proxy.JediProxyHandler(context, jediProxy);

--- a/src/test/extension.autocomplete.test.ts
+++ b/src/test/extension.autocomplete.test.ts
@@ -140,7 +140,7 @@ suite('Code Definition', () => {
             const position = new vscode.Position(30, 5);
             return vscode.commands.executeCommand<vscode.Location[]>('vscode.executeDefinitionProvider', textDocument.uri, position);
         }).then(def => {
-            assert.equal(def.length, 1, 'Definition lenght is incorrect');
+            assert.equal(def.length, 1, 'Definition length is incorrect');
             assert.equal(`${def[0].range.start.line},${def[0].range.start.character}`, '17,4', 'Start position is incorrect');
             assert.equal(`${def[0].range.end.line},${def[0].range.end.character}`, '21,11', 'End position is incorrect');
         }).then(done, done);
@@ -158,7 +158,7 @@ suite('Code Definition', () => {
             const position = new vscode.Position(1, 5);
             return vscode.commands.executeCommand<vscode.Location[]>('vscode.executeDefinitionProvider', textDocument.uri, position);
         }).then(def => {
-            assert.equal(def.length, 1, 'Definition lenght is incorrect');
+            assert.equal(def.length, 1, 'Definition length is incorrect');
             assert.equal(`${def[0].range.start.line},${def[0].range.start.character}`, '0,0', 'Start position is incorrect');
             assert.equal(`${def[0].range.end.line},${def[0].range.end.character}`, '5,11', 'End position is incorrect');
             assert.equal(def[0].uri.fsPath, fileTwo, 'File is incorrect');
@@ -177,7 +177,7 @@ suite('Code Definition', () => {
             const position = new vscode.Position(25, 6);
             return vscode.commands.executeCommand<vscode.Location[]>('vscode.executeDefinitionProvider', textDocument.uri, position);
         }).then(def => {
-            assert.equal(def.length, 1, 'Definition lenght is incorrect');
+            assert.equal(def.length, 1, 'Definition length is incorrect');
             assert.equal(`${def[0].range.start.line},${def[0].range.start.character}`, '10,4', 'Start position is incorrect');
             assert.equal(`${def[0].range.end.line},${def[0].range.end.character}`, '16,35', 'End position is incorrect');
             assert.equal(def[0].uri.fsPath, fileEncoding, 'File is incorrect');
@@ -196,7 +196,7 @@ suite('Code Definition', () => {
             const position = new vscode.Position(1, 11);
             return vscode.commands.executeCommand<vscode.Location[]>('vscode.executeDefinitionProvider', textDocument.uri, position);
         }).then(def => {
-            assert.equal(def.length, 1, 'Definition lenght is incorrect');
+            assert.equal(def.length, 1, 'Definition length is incorrect');
             assert.equal(`${def[0].range.start.line},${def[0].range.start.character}`, '18,0', 'Start position is incorrect');
             assert.equal(`${def[0].range.end.line},${def[0].range.end.character}`, '23,16', 'End position is incorrect');
             assert.equal(def[0].uri.fsPath, fileEncoding, 'File is incorrect');
@@ -231,11 +231,11 @@ suite('Hover Definition', () => {
             const position = new vscode.Position(30, 5);
             return vscode.commands.executeCommand<vscode.Hover[]>('vscode.executeHoverProvider', textDocument.uri, position);
         }).then(def => {
-            assert.equal(def.length, 1, 'Definition lenght is incorrect');
+            assert.equal(def.length, 1, 'Definition length is incorrect');
             assert.equal(`${def[0].range.start.line},${def[0].range.start.character}`, '30,4', 'Start position is incorrect');
             assert.equal(`${def[0].range.end.line},${def[0].range.end.character}`, '30,11', 'End position is incorrect');
             assert.equal(def[0].contents.length, 2, 'Invalid content items');
-            assert.equal(def[0].contents[0]['value'], 'def method1(self)', 'function signature incorrect');
+            assert.equal(def[0].contents[0]['value'], 'def method1()', 'function signature incorrect');
             assert.equal(def[0].contents[1], `This is method1`, 'Invalid conents');
         }).then(done, done);
     });
@@ -252,7 +252,7 @@ suite('Hover Definition', () => {
             const position = new vscode.Position(1, 12);
             return vscode.commands.executeCommand<vscode.Hover[]>('vscode.executeHoverProvider', textDocument.uri, position);
         }).then(def => {
-            assert.equal(def.length, 1, 'Definition lenght is incorrect');
+            assert.equal(def.length, 1, 'Definition length is incorrect');
             assert.equal(`${def[0].range.start.line},${def[0].range.start.character}`, '1,9', 'Start position is incorrect');
             assert.equal(`${def[0].range.end.line},${def[0].range.end.character}`, '1,12', 'End position is incorrect');
             assert.equal(def[0].contents[0]['value'], 'def fun()', 'function signature incorrect');
@@ -272,7 +272,7 @@ suite('Hover Definition', () => {
             const position = new vscode.Position(25, 6);
             return vscode.commands.executeCommand<vscode.Hover[]>('vscode.executeHoverProvider', textDocument.uri, position);
         }).then(def => {
-            assert.equal(def.length, 1, 'Definition lenght is incorrect');
+            assert.equal(def.length, 1, 'Definition length is incorrect');
             assert.equal(`${def[0].range.start.line},${def[0].range.start.character}`, '25,4', 'Start position is incorrect');
             assert.equal(`${def[0].range.end.line},${def[0].range.end.character}`, '25,7', 'End position is incorrect');
             assert.equal(def[0].contents[0]['value'], 'def bar()', 'function signature incorrect');
@@ -293,7 +293,7 @@ suite('Hover Definition', () => {
             const position = new vscode.Position(1, 11);
             return vscode.commands.executeCommand<vscode.Hover[]>('vscode.executeHoverProvider', textDocument.uri, position);
         }).then(def => {
-            assert.equal(def.length, 1, 'Definition lenght is incorrect');
+            assert.equal(def.length, 1, 'Definition length is incorrect');
             assert.equal(`${def[0].range.start.line},${def[0].range.start.character}`, '1,5', 'Start position is incorrect');
             assert.equal(`${def[0].range.end.line},${def[0].range.end.character}`, '1,16', 'End position is incorrect');
             assert.equal(def[0].contents[0]['value'], 'def showMessage()', 'Invalid content items');
@@ -314,7 +314,7 @@ suite('Hover Definition', () => {
             const position = new vscode.Position(5, 1);
             return vscode.commands.executeCommand<vscode.Hover[]>('vscode.executeHoverProvider', textDocument.uri, position);
         }).then(def => {
-            assert.equal(def.length, 0, 'Definition lenght is incorrect');
+            assert.equal(def.length, 0, 'Definition length is incorrect');
         }).then(done, done);
     });
 
@@ -330,7 +330,7 @@ suite('Hover Definition', () => {
             const position = new vscode.Position(3, 1);
             return vscode.commands.executeCommand<vscode.Hover[]>('vscode.executeHoverProvider', textDocument.uri, position);
         }).then(def => {
-            assert.equal(def.length, 0, 'Definition lenght is incorrect');
+            assert.equal(def.length, 0, 'Definition length is incorrect');
         }).then(done, done);
     });
 
@@ -346,10 +346,10 @@ suite('Hover Definition', () => {
             const position = new vscode.Position(11, 15);
             return vscode.commands.executeCommand<vscode.Hover[]>('vscode.executeHoverProvider', textDocument.uri, position);
         }).then(def => {
-            assert.equal(def.length, 1, 'Definition lenght is incorrect');
+            assert.equal(def.length, 1, 'Definition length is incorrect');
             assert.equal(`${def[0].range.start.line},${def[0].range.start.character}`, '11,12', 'Start position is incorrect');
             assert.equal(`${def[0].range.end.line},${def[0].range.end.character}`, '11,18', 'End position is incorrect');
-            assert.equal(def[0].contents[0]['value'], 'class Random(self, x=None)', 'Invalid content items');
+            assert.equal(def[0].contents[0]['value'], 'class Random(x=None)', 'Invalid content items');
             const documentation = `Random number generator base class used by bound module functions.${EOL}${EOL}` +
                 `Used to instantiate instances of Random to get generators that don't${EOL}` +
                 `share state.${EOL}${EOL}` +
@@ -375,10 +375,10 @@ suite('Hover Definition', () => {
             const position = new vscode.Position(12, 10);
             return vscode.commands.executeCommand<vscode.Hover[]>('vscode.executeHoverProvider', textDocument.uri, position);
         }).then(def => {
-            assert.equal(def.length, 1, 'Definition lenght is incorrect');
+            assert.equal(def.length, 1, 'Definition length is incorrect');
             assert.equal(`${def[0].range.start.line},${def[0].range.start.character}`, '12,5', 'Start position is incorrect');
             assert.equal(`${def[0].range.end.line},${def[0].range.end.character}`, '12,12', 'End position is incorrect');
-            assert.equal(def[0].contents[0]['value'], 'def randint(self, a, b)', 'Invalid content items');
+            assert.equal(def[0].contents[0]['value'], 'def randint(a, b)', 'Invalid content items');
             const documentation = `Return random integer in range [a, b], including both end points.`;
             assert.equal(def[0].contents[1], documentation, 'Invalid conents');
         }).then(done, done);
@@ -396,11 +396,11 @@ suite('Hover Definition', () => {
             const position = new vscode.Position(8, 14);
             return vscode.commands.executeCommand<vscode.Hover[]>('vscode.executeHoverProvider', textDocument.uri, position);
         }).then(def => {
-            assert.equal(def.length, 1, 'Definition lenght is incorrect');
+            assert.equal(def.length, 1, 'Definition length is incorrect');
             assert.equal(`${def[0].range.start.line},${def[0].range.start.character}`, '8,11', 'Start position is incorrect');
             assert.equal(`${def[0].range.end.line},${def[0].range.end.character}`, '8,15', 'End position is incorrect');
             assert.equal(def[0].contents[0]['value'], 'def acos(x)', 'Invalid content items');
-            const documentation = `Return the arc cosine (measured in radians) of x.`;
+            const documentation = `acos(x)${EOL}${EOL}Return the arc cosine (measured in radians) of x.`;
             assert.equal(def[0].contents[1], documentation, 'Invalid conents');
         }).then(done, done);
     });
@@ -417,13 +417,32 @@ suite('Hover Definition', () => {
             const position = new vscode.Position(14, 14);
             return vscode.commands.executeCommand<vscode.Hover[]>('vscode.executeHoverProvider', textDocument.uri, position);
         }).then(def => {
-            assert.equal(def.length, 1, 'Definition lenght is incorrect');
+            assert.equal(def.length, 1, 'Definition length is incorrect');
             assert.equal(`${def[0].range.start.line},${def[0].range.start.character}`, '14,9', 'Start position is incorrect');
             assert.equal(`${def[0].range.end.line},${def[0].range.end.character}`, '14,15', 'End position is incorrect');
-            const signature = `class Thread(self, group=None, target=None, name=None,${EOL}args=(), kwargs=None, verbose=None)`;
+            const signature = `class Thread(group=None, target=None, name=None, args=(), kwargs=None, verbose=None)`;
             assert.equal(def[0].contents[0]['value'], signature, 'Invalid content items');
             const documentation = `A class that represents a thread of control.${EOL}${EOL}This class can be safely subclassed in a limited fashion.`;
             assert.equal(def[0].contents[1], documentation, 'Invalid conents');
+        }).then(done, done);
+    });
+
+    test('Variable', done => {
+        let textEditor: vscode.TextEditor;
+        let textDocument: vscode.TextDocument;
+        return vscode.workspace.openTextDocument(fileHover).then(document => {
+            textDocument = document;
+            return vscode.window.showTextDocument(textDocument);
+        }).then(editor => {
+            assert(vscode.window.activeTextEditor, 'No active editor');
+            textEditor = editor;
+            const position = new vscode.Position(6, 2);
+            return vscode.commands.executeCommand<vscode.Hover[]>('vscode.executeHoverProvider', textDocument.uri, position);
+        }).then(def => {
+            assert.equal(def.length, 1, 'Definition length is incorrect');
+            assert.equal(def[0].contents.length, 1, 'Only expected one result');
+            const signature = 'Random';
+            assert.equal(def[0].contents[0]['value'], signature, 'Invalid content items');
         }).then(done, done);
     });
 });


### PR DESCRIPTION
I'm playing with the idea of providing type annotations on hover instead of duplicating autocomplete results. This is quite useful especially when combined with PEP 484 annotations or comments with type hints.