### PR TITLE
Change tags file default path to `.vscode/tags`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1057,7 +1057,7 @@
 				},
 				"python.workspaceSymbols.tagFilePath": {
 					"type": "string",
-					"default": "${workspaceRoot}/tags",
+					"default": "${workspaceRoot}/.vscode/tags",
 					"description": "Fully qualified path to tag file (exuberant ctag file), used to provide workspace symbols."
 				},
 				"python.workspaceSymbols.enabled": {


### PR DESCRIPTION
Motivation for this change:
The appearance of the `tags` file at the root of the project is a bit surprising when using the extension. Since that file is only relevant when using vscode with the python extension, it should live in the `.vscode` folder.

See https://github.com/DonJayamanne/pythonVSCode/issues/721