### PR TITLE
fix rename error if using 'LF' eol in windows

### DIFF
--- a/src/client/common/utils.ts
+++ b/src/client/common/utils.ts
@@ -8,7 +8,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import * as child_process from 'child_process';
 import * as settings from './configSettings';
-import { CancellationToken } from 'vscode';
+import { CancellationToken, TextDocument, Range, Position } from 'vscode';
 import { isNotInstalledError } from './helpers';
 import { mergeEnvVariables, parseEnvFile } from './envFileParser';
 
@@ -303,16 +303,19 @@ export function getCustomEnvVars(): any {
     return null;
 }
 
-export function getWindowsLineEndingCount(text:String, offset:Number)  {
-    const eolPattern = new RegExp('\r', 'g');
+export function getWindowsLineEndingCount(document:TextDocument, offset:Number)  {
+    const eolPattern = new RegExp('\r\n', 'g');
     const readBlock = 1024;
     let count = 0;
 
     // In order to prevent the one-time loading of large files from taking up too much memory
     for (let pos = 0; pos < offset; pos += readBlock)   {
-        let partialText = text.slice(pos, pos + readBlock);
-        let cr = partialText.match(eolPattern);
+        let startAt = document.positionAt(pos)
+        let endAt = document.positionAt(pos + readBlock);
 
+        let text = document.getText(new Range(startAt, endAt));
+        let cr = text.match(eolPattern);
+        
         count += cr ? cr.length : 0;
     }
     return count;

--- a/src/client/common/utils.ts
+++ b/src/client/common/utils.ts
@@ -302,3 +302,18 @@ export function getCustomEnvVars(): any {
     }
     return null;
 }
+
+export function getWindowsLineEndingCount(text:String, offset:Number)  {
+    const eolPattern = new RegExp('\r', 'g');
+    const readBlock = 1024;
+    let count = 0;
+
+    // In order to prevent the one-time loading of large files from taking up too much memory
+    for (let pos = 0; pos < offset; pos += readBlock)   {
+        let partialText = text.slice(pos, pos + readBlock);
+        let cr = partialText.match(eolPattern);
+
+        count += cr ? cr.length : 0;
+    }
+    return count;
+}

--- a/src/client/refactor/proxy.ts
+++ b/src/client/refactor/proxy.ts
@@ -6,7 +6,7 @@ import * as child_process from 'child_process';
 import { IPythonSettings } from '../common/configSettings';
 import { REFACTOR } from '../common/telemetryContracts';
 import { sendTelemetryEvent, Delays } from '../common/telemetry';
-import { IS_WINDOWS, getCustomEnvVars } from '../common/utils';
+import { IS_WINDOWS, getCustomEnvVars, getWindowsLineEndingCount } from '../common/utils';
 import { mergeEnvVariables } from '../common/envFileParser';
 
 export class RefactorProxy extends vscode.Disposable {
@@ -39,8 +39,11 @@ export class RefactorProxy extends vscode.Disposable {
         // get line count
         // Rope always uses LF, instead of CRLF on windows, funny isn't it
         // So for each line, reduce one characer (for CR)
+        // But Not all Windows users use CRLF
         const offset = document.offsetAt(position);
-        return offset - position.line;
+
+        const winEols = getWindowsLineEndingCount(document.getText(), offset);        
+        return offset - winEols;
     }
     rename<T>(document: vscode.TextDocument, name: string, filePath: string, range: vscode.Range, options?: vscode.TextEditorOptions): Promise<T> {
         if (!options) {

--- a/src/client/refactor/proxy.ts
+++ b/src/client/refactor/proxy.ts
@@ -41,8 +41,8 @@ export class RefactorProxy extends vscode.Disposable {
         // So for each line, reduce one characer (for CR)
         // But Not all Windows users use CRLF
         const offset = document.offsetAt(position);
-
-        const winEols = getWindowsLineEndingCount(document.getText(), offset);        
+        const winEols = getWindowsLineEndingCount(document, offset);        
+        
         return offset - winEols;
     }
     rename<T>(document: vscode.TextDocument, name: string, filePath: string, range: vscode.Range, options?: vscode.TextEditorOptions): Promise<T> {


### PR DESCRIPTION
Hello, DonJayamanne

I found the `rename` feature goes wrong when i edit a py file with `LF` eol on Windows(7/8/10).  
![Bug GIF](https://cloud.githubusercontent.com/assets/1303118/22978485/de341650-f3cd-11e6-9713-62abc9ae1a7c.gif)

but if I convert the file EOL to `CRLF`,  everything is ok.

![CRLF is OK](https://cloud.githubusercontent.com/assets/1303118/22978572/3749acfa-f3ce-11e6-81b9-5169a11dacf1.gif)

Some editor / IDE will keep both `LF` and `CRLF` in one file. So the numbers of character (`CR`) are not necessarily equal to the line numbers

Here is the effect of this patch:
![This patch](https://cloud.githubusercontent.com/assets/1303118/22979113/28f3f50a-f3d0-11e6-8507-c4cb437abb35.gif)
