### PR TITLE
Fix the date in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,14 @@
-### Version 0.6.3 (19 March 2017)
+### Version 0.6.3 (19 April 2017)
 * Fix debugger issue [#893](https://github.com/DonJayamanne/pythonVSCode/issues/893)
 * Improvements to debugging unit tests (check if string starts with, instead of comparing equality) [#797](https://github.com/DonJayamanne/pythonVSCode/issues/797)  
 
-### Version 0.6.2 (13 March 2017)
+### Version 0.6.2 (13 April 2017)
 * Fix incorrect indenting [#880](https://github.com/DonJayamanne/pythonVSCode/issues/880)
 
 #### Thanks  
 * [Yuwei Ba](https://github.com/ibigbug)  
   
-### Version 0.6.1 (10 March 2017)
+### Version 0.6.1 (10 April 2017)
 * Add support for new variable syntax in upcoming VS Code release [#774](https://github.com/DonJayamanne/pythonVSCode/issues/774), [#855](https://github.com/DonJayamanne/pythonVSCode/issues/855), [#873](https://github.com/DonJayamanne/pythonVSCode/issues/873), [#823](https://github.com/DonJayamanne/pythonVSCode/issues/823)  
 * Resolve issues in code refactoring [#802](https://github.com/DonJayamanne/pythonVSCode/issues/802), [#824](https://github.com/DonJayamanne/pythonVSCode/issues/824), [#825](https://github.com/DonJayamanne/pythonVSCode/pull/825)  
 * Changes to labels in Python Interpreter lookup [#815](https://github.com/DonJayamanne/pythonVSCode/pull/815)  

--- a/README.md
+++ b/README.md
@@ -100,17 +100,17 @@ For further information and details continue through to the [documentation](http
 
 ## [Change Log](https://github.com/DonJayamanne/pythonVSCode/blob/master/CHANGELOG.md)
 
-### Version 0.6.3 (19 March 2017)
+### Version 0.6.3 (19 April 2017)
 * Fix debugger issue [#893](https://github.com/DonJayamanne/pythonVSCode/issues/893)
 
-### Version 0.6.2 (13 March 2017)
+### Version 0.6.2 (13 April 2017)
 * Fix incorrect indenting [#880](https://github.com/DonJayamanne/pythonVSCode/issues/880)
 * Improvements to debugging unit tests (check if string starts with, instead of comparing equality) [#797](https://github.com/DonJayamanne/pythonVSCode/issues/797)  
 
 #### Thanks  
 * [Yuwei Ba](https://github.com/ibigbug)  
 
-### Version 0.6.1 (10 March 2017)
+### Version 0.6.1 (10 April 2017)
 * Add support for new variable syntax in upcoming VS Code release [#774](https://github.com/DonJayamanne/pythonVSCode/issues/774), [#855](https://github.com/DonJayamanne/pythonVSCode/issues/855), [#873](https://github.com/DonJayamanne/pythonVSCode/issues/873), [#823](https://github.com/DonJayamanne/pythonVSCode/issues/823)  
 * Resolve issues in code refactoring [#802](https://github.com/DonJayamanne/pythonVSCode/issues/802), [#824](https://github.com/DonJayamanne/pythonVSCode/issues/824), [#825](https://github.com/DonJayamanne/pythonVSCode/pull/825)  
 * Changes to labels in Python Interpreter lookup [#815](https://github.com/DonJayamanne/pythonVSCode/pull/815)  


### PR DESCRIPTION
I'm pretty sure that 0.6.1 ~ 0.6.3 is released in April, but I don't know how to get the exactly time in the marketplace, so I just changed March to April.