### PR TITLE
Split docstring with /\r?\n/ rather than os.EOL. fix #888

### DIFF
--- a/src/client/providers/hoverProvider.ts
+++ b/src/client/providers/hoverProvider.ts
@@ -34,7 +34,7 @@ export class PythonHoverProvider implements vscode.HoverProvider {
                 }
             }
             if (item.docstring) {
-                let lines = item.docstring.split(EOL);
+                let lines = item.docstring.split(/\r?\n/);
                 // If the docstring starts with the signature, then remove those lines from the docstring
                 if (lines.length > 0 && item.signature.indexOf(lines[0]) === 0) {
                     lines.shift();


### PR DESCRIPTION
The new line character in docstring doesn't depend on `os.EOL`

On Windows, the `os.EOL` is `\r\n`, so the `\n` in docstring won't be split.

![nosplit](https://cloud.githubusercontent.com/assets/7588612/25470326/4a296db6-2b54-11e7-9f02-5dc3f10173a2.png)

And this will fix #888.