### PR TITLE
outdent line following continue / break / return statements

### DIFF
--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -85,7 +85,11 @@ export function activate(context: vscode.ExtensionContext) {
             {
                 beforeText: /^ *#.*$/,
                 afterText: /.+$/,
-                action: { indentAction: vscode.IndentAction.None, appendText: '# ' }
+                action: { indentAction: vscode.IndentAction.None, appendText: '# ' },
+            },
+            {
+                beforeText: /^\s+(continue|break|return).*$/,
+                action: {indentAction: vscode.IndentAction.Outdent},
             }
         ]
     });

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -88,7 +88,7 @@ export function activate(context: vscode.ExtensionContext) {
                 action: { indentAction: vscode.IndentAction.None, appendText: '# ' },
             },
             {
-                beforeText: /^\s+(continue|break|return).*$/,
+                beforeText: /^\s+(continue|break|return)\b.*$/,
                 action: {indentAction: vscode.IndentAction.Outdent},
             }
         ]


### PR DESCRIPTION
Automatically outdenting lines following "continue", "break" or "return"
statements seems natural and consistent with other editors (e.g. emacs
or vim) behaviour.