### PR TITLE
Fix Workspace Symbols path on Windows.

### DIFF
--- a/src/client/workspaceSymbols/generator.ts
+++ b/src/client/workspaceSymbols/generator.ts
@@ -28,7 +28,7 @@ export class Generator implements vscode.Disposable {
     }
 
     generateWorkspaceTags(): Promise<any> {
-        const tagFile = pythonSettings.workspaceSymbols.tagFilePath;
+        const tagFile = path.normalize(pythonSettings.workspaceSymbols.tagFilePath);
         return this.generateTags(tagFile, { directory: vscode.workspace.rootPath });
     }
 


### PR DESCRIPTION
This should fix #816 and #829. The path to the tags file had both / and \ in the string on Windows.
E.g. `d:\code\python\steam-clientserver/.vscode/tags`
