### PR TITLE
Fix python interactive mode flag issue

### DIFF
--- a/src/client/providers/execInTerminalProvider.ts
+++ b/src/client/providers/execInTerminalProvider.ts
@@ -66,8 +66,13 @@ function execInTerminal(fileUri?: vscode.Uri) {
     if (filePath.indexOf(' ') > 0) {
         filePath = `"${filePath}"`;
     }
+    //Auto save when running in terminal
+    vscode.commands.executeCommand("workbench.action.files.save");
 
-    terminal = terminal ? terminal : vscode.window.createTerminal(`Python`);
+    //Close the current active python terminal
+    if(terminal) terminal.dispose();
+    terminal = vscode.window.createTerminal(`Python`);
+
     if (pythonSettings.terminal && pythonSettings.terminal.executeInFileDir) {
         const fileDirPath = path.dirname(filePath);
         if (fileDirPath !== vscode.workspace.rootPath && fileDirPath.substring(1) !== vscode.workspace.rootPath) {


### PR DESCRIPTION
When users add the interactive mode `-i` in `"python.terminal.launchArgs"` a bug occurs that causes the command `python.execInTerminal` to not run as long as a current instance of the python shell is already active.

![vscode_py_ibug](https://user-images.githubusercontent.com/11269928/28226905-a59603e2-688c-11e7-8f3b-a2fda09b1096.gif)

- The code is modified to close the current active python terminal and start it again if it is already active
- The `python.execInTerminal` will also auto save the current opened file before running it