### PR TITLE
Add PEP 526 AutoCompletion

### DIFF
--- a/pythonFiles/preview/jedi/evaluate/__init__.py
+++ b/pythonFiles/preview/jedi/evaluate/__init__.py
@@ -162,7 +162,7 @@ class Evaluator(object):
             types = finder.check_tuple_assignments(self, types, seek_name)
 
         first_operation = stmt.first_operation()
-        if first_operation not in ('=', None) and not isinstance(stmt, er.InstanceElement):  # TODO don't check for this.
+        if first_operation not in ('=', None) and not isinstance(stmt, er.InstanceElement) and first_operation.type == 'operator':  # TODO don't check for this.
             # `=` is always the last character in aug assignments -> -1
             operator = copy.copy(first_operation)
             operator.value = operator.value[:-1]
@@ -327,6 +327,8 @@ class Evaluator(object):
             types = types
         elif element.type == 'eval_input':
             types = self._eval_element_not_cached(element.children[0])
+        elif element.type == 'annassign':
+            types = self.eval_element(element.children[1])
         else:
             types = precedence.calculate_children(self, element.children)
         debug.dbg('eval_element result %s', types)

--- a/pythonFiles/preview/jedi/parser/tree.py
+++ b/pythonFiles/preview/jedi/parser/tree.py
@@ -1522,9 +1522,14 @@ class ExprStmt(BaseNode, DocstringMixin):
     __slots__ = ()
 
     def get_defined_names(self):
-        return list(chain.from_iterable(_defined_names(self.children[i])
-                                        for i in range(0, len(self.children) - 2, 2)
-                                        if '=' in self.children[i + 1].value))
+        names = []  
+        if self.children[1].type == 'annassign':  
+            names = _defined_names(self.children[0])  
+        return list(chain.from_iterable(  
+            _defined_names(self.children[i])  
+            for i in range(0, len(self.children) - 2, 2)  
+            if '=' in self.children[i + 1].value)  
+        ) + names
 
     def get_rhs(self):
         """Returns the right-hand-side of the equals."""


### PR DESCRIPTION
By following instructions similar to this link:
https://github.com/davidhalter/jedi/commit/3f09f3a30432dacdc224a2f819a458a8218e3723

It is now possible to give auto-completion to any variable declared in the following fashion. For example
```python
test: str = "PEP 562 Support"
test.split()  # now it has auto-completion
```
Related issues can be found here:
https://github.com/DonJayamanne/pythonVSCode/issues/1101