### PR TITLE
Fix #996 async with EXPR as VAR

### DIFF
--- a/snippets/python.json
+++ b/snippets/python.json
@@ -223,7 +223,7 @@
     "async/with": {
         "prefix": "async/with",
         "body": [
-            "async with ${1:expr} in ${2:var}:",
+            "async with ${1:expr} as ${2:var}:",
             "\t${3:block}"
         ],
         "description": "Code snippet for a async with statement"


### PR DESCRIPTION
Fix #996 async with EXPR as VAR

A tiny issue, but could be annoying.