### PR TITLE
Fix Issue "OSError: Too Many Open Files (#1072)"

### DIFF
--- a/pythonFiles/completion.py
+++ b/pythonFiles/completion.py
@@ -22,6 +22,7 @@ class RedirectStdout(object):
     def __exit__(self, exc_type, exc_value, traceback):
         self._new_stdout.flush()
         os.dup2(self.oldstdout_fno, 1)
+        os.close(self.oldstdout_fno)
 
 class JediCompletion(object):
     basic_types = {


### PR DESCRIPTION
Close the file descriptor "self.oldstdout_fno" after line 24 in completion.py, since it is no more used. Leaving it opened will cause the Too Many Open Files error when the _enter_ function is called many times.