### PR TITLE
Allow running linters either as modules or commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -1134,33 +1134,33 @@
 				},
 				"python.linting.prospectorPath": {
 					"type": "string",
-					"default": "prospector",
-					"description": "Path to Prospector, you can use a custom version of prospector by modifying this setting to include the full path."
+					"default": ":prospector",
+					"description": "Module or Path to Prospector. You can use a custom version of prospector by modifying this setting to include the path to the command (e.g `${workspaceRoot}/bin/prospector`), or you can indicate a Python module to run with `python -m module` by specifying `:module`."
 				},
 				"python.linting.pylintPath": {
 					"type": "string",
-					"default": "pylint",
-					"description": "Path to Pylint, you can use a custom version of pylint by modifying this setting to include the full path."
+					"default": ":pylint",
+					"description": "Module or Path to Pylint. You can use a custom version of pylint by modifying this setting to include the path to the command (e.g `${workspaceRoot}/bin/pylint`), or you can indicate a Python module to run with `python -m module` by specifying `:module`."
 				},
 				"python.linting.pep8Path": {
 					"type": "string",
-					"default": "pep8",
-					"description": "Path to pep8, you can use a custom version of pep8 by modifying this setting to include the full path."
+					"default": ":pep8",
+					"description": "Module or Path to pep8. You can use a custom version of pep8 by modifying this setting to include the path to the command (e.g `${workspaceRoot}/bin/pep8`), or you can indicate a Python module to run with `python -m module` by specifying `:module`."
 				},
 				"python.linting.flake8Path": {
 					"type": "string",
-					"default": "flake8",
-					"description": "Path to flake8, you can use a custom version of flake8 by modifying this setting to include the full path."
+					"default": ":flake8",
+					"description": "Module or Path to flake8. You can use a custom version of flake8 by modifying this setting to include the path to the command (e.g `${workspaceRoot}/bin/flake8`), or you can indicate a Python module to run with `python -m module` by specifying `:module`."
 				},
 				"python.linting.pydocstylePath": {
 					"type": "string",
-					"default": "pydocstyle",
-					"description": "Path to pydocstyle, you can use a custom version of pydocstyle by modifying this setting to include the full path."
+					"default": ":pydocstyle",
+					"description": "Module or Path to pydocstyle. You can use a custom version of pydocstyle by modifying this setting to include the path to the command (e.g `${workspaceRoot}/bin/pydocstyle`), or you can indicate a Python module to run with `python -m module` by specifying `:module`."
 				},
 				"python.linting.mypyPath": {
 					"type": "string",
-					"default": "mypy",
-					"description": "Path to mypy, you can use a custom version of mypy by modifying this setting to include the full path."
+					"default": ":mypy",
+					"description": "Module or Path to mypy. You can use a custom version of mypy by modifying this setting to include the path to the command (e.g `${workspaceRoot}/bin/mypy`), or you can indicate a Python module to run with `python -m module` by specifying `:module`."
 				},
 				"python.linting.prospectorArgs": {
 					"type": "array",
@@ -1400,8 +1400,8 @@
 				},
 				"python.linting.pylamaPath": {
 					"type": "string",
-					"default": "pylama",
-					"description": "Path to pylama, you can use a custom version of pylama by modifying this setting to include the full path."
+					"default": ":pylama",
+					"description": "Module or Path to pylama. You can use a custom version of pylama by modifying this setting to include the path to the command (e.g `${workspaceRoot}/bin/pylama`), or you can indicate a Python module to run with `python -m module` by specifying `:module`."
 				},
 				"python.linting.pylamaArgs": {
 					"type": "array",

--- a/src/client/linters/baseLinter.ts
+++ b/src/client/linters/baseLinter.ts
@@ -73,9 +73,10 @@ export abstract class BaseLinter {
         let linterPath:string = linterSettings[`${this.Id}Path`];
         let linterArgs:string[] = Array.isArray(linterSettings[`${this.Id}Args`]) ? linterSettings[`${this.Id}Args`] : [];
 
-        if (linterArgs.length === 0 && ProductExecutableAndArgs.has(Product[this.Id]) && linterPath === this.Id) {
-            linterPath = ProductExecutableAndArgs.get(Product[this.Id]).executable;
-            linterArgs = ProductExecutableAndArgs.get(Product[this.Id]).args;
+        // if linterPath is like ':flake8' call linter as `python -m flake8 [args...]` instead of `flake8 [args...]`
+        if (linterPath[0] == ':') {
+            linterArgs = (['-m', linterPath.substring(1)]);
+            linterPath = this.pythonSettings.pythonPath;
         }
 
         linterArgs = linterArgs.concat(this.getExtraLinterArgs(document));

--- a/src/client/linters/baseLinter.ts
+++ b/src/client/linters/baseLinter.ts
@@ -2,7 +2,7 @@
 import { execPythonFile } from './../common/utils';
 import * as settings from './../common/configSettings';
 import { OutputChannel } from 'vscode';
-import { Installer, Product } from '../common/installer';
+import { Installer, Product, ProductExecutableAndArgs } from '../common/installer';
 import * as vscode from 'vscode';
 import { ErrorHandler } from './errorHandlers/main';
 
@@ -62,8 +62,40 @@ export abstract class BaseLinter {
         this.pythonSettings = settings.PythonSettings.getInstance();
         this._errorHandler = new ErrorHandler(this.Id, product, new Installer(), this.outputChannel);
     }
-    public abstract isEnabled(): Boolean;
-    public abstract runLinter(document: vscode.TextDocument, cancellation: vscode.CancellationToken): Promise<ILintMessage[]>;
+    public abstract getExtraLinterArgs(document: vscode.TextDocument): string[];
+
+    public isEnabled(): Boolean {
+        return this.pythonSettings.linting[`${this.Id}Enabled`];
+    }
+
+    public getLinterPathAndArgs(document: vscode.TextDocument): [string, string[]] {
+        let linterSettings = this.pythonSettings.linting;
+        let linterPath:string = linterSettings[`${this.Id}Path`];
+        let linterArgs:string[] = Array.isArray(linterSettings[`${this.Id}Args`]) ? linterSettings[`${this.Id}Args`] : [];
+
+        if (linterArgs.length === 0 && ProductExecutableAndArgs.has(Product[this.Id]) && linterPath === this.Id) {
+            linterPath = ProductExecutableAndArgs.get(Product[this.Id]).executable;
+            linterArgs = ProductExecutableAndArgs.get(Product[this.Id]).args;
+        }
+
+        linterArgs = linterArgs.concat(this.getExtraLinterArgs(document));
+        return [linterPath, linterArgs];
+    }
+
+    public runLinter(document: vscode.TextDocument, cancellation: vscode.CancellationToken): Promise<ILintMessage[]> {
+        let [linterPath, linterArgs] = this.getLinterPathAndArgs(document);
+        return new Promise<ILintMessage[]>((resolve, reject) => {
+            this.run(linterPath, linterArgs, document, this.workspaceRootPath, cancellation).then(messages => {
+                messages.forEach(msg => {
+                    msg.severity = this.parseMessagesSeverity(msg.type, this.pythonSettings.linting[`${this.Id}CategorySeverity`]);
+                    msg.code = msg.type;
+                });
+
+                resolve(messages);
+            }, reject);
+        });
+    }
+
 
     protected parseMessagesSeverity(error: string, categorySeverity: any): LintMessageSeverity {
         if (categorySeverity[error]) {

--- a/src/client/linters/flake8.ts
+++ b/src/client/linters/flake8.ts
@@ -2,7 +2,7 @@
 
 import * as baseLinter from './baseLinter';
 import { OutputChannel } from 'vscode';
-import { Product, ProductExecutableAndArgs } from '../common/installer';
+import { Product } from '../common/installer';
 import { TextDocument, CancellationToken } from 'vscode';
 
 export class Linter extends baseLinter.BaseLinter {
@@ -12,30 +12,7 @@ export class Linter extends baseLinter.BaseLinter {
         super('flake8', Product.flake8, outputChannel, workspaceRootPath);
     }
 
-    public isEnabled(): Boolean {
-        return this.pythonSettings.linting.flake8Enabled;
-    }
-    public runLinter(document: TextDocument, cancellation: CancellationToken): Promise<baseLinter.ILintMessage[]> {
-        if (!this.pythonSettings.linting.flake8Enabled) {
-            return Promise.resolve([]);
-        }
-
-        let flake8Path = this.pythonSettings.linting.flake8Path;
-        let flake8Args = Array.isArray(this.pythonSettings.linting.flake8Args) ? this.pythonSettings.linting.flake8Args : [];
-
-        if (flake8Args.length === 0 && ProductExecutableAndArgs.has(Product.flake8) && flake8Path.toLocaleLowerCase() === 'flake8') {
-            flake8Path = ProductExecutableAndArgs.get(Product.flake8).executable;
-            flake8Args = ProductExecutableAndArgs.get(Product.flake8).args;
-        }
-
-        return new Promise<baseLinter.ILintMessage[]>((resolve, reject) => {
-            this.run(flake8Path, flake8Args.concat(['--format=%(row)d,%(col)d,%(code).1s,%(code)s:%(text)s', document.uri.fsPath]), document, this.workspaceRootPath, cancellation).then(messages => {
-                messages.forEach(msg => {
-                    msg.severity = this.parseMessagesSeverity(msg.type, this.pythonSettings.linting.flake8CategorySeverity);
-                });
-
-                resolve(messages);
-            }, reject);
-        });
+    public getExtraLinterArgs(document: TextDocument): string[] {
+        return ['--format=%(row)d,%(col)d,%(code).1s,%(code)s:%(text)s', document.uri.fsPath];
     }
 }

--- a/src/client/linters/mypy.ts
+++ b/src/client/linters/mypy.ts
@@ -2,7 +2,7 @@
 
 import * as baseLinter from './baseLinter';
 import { OutputChannel } from 'vscode';
-import { Product, ProductExecutableAndArgs } from '../common/installer';
+import { Product } from '../common/installer';
 import { TextDocument, CancellationToken } from 'vscode';
 
 const REGEX = '(?<file>.py):(?<line>\\d+): (?<type>\\w+): (?<message>.*)\\r?(\\n|$)';
@@ -12,31 +12,7 @@ export class Linter extends baseLinter.BaseLinter {
         super('mypy', Product.mypy, outputChannel, workspaceRootPath);
     }
 
-    public isEnabled(): Boolean {
-        return this.pythonSettings.linting.mypyEnabled;
-    }
-    public runLinter(document: TextDocument, cancellation: CancellationToken): Promise<baseLinter.ILintMessage[]> {
-        if (!this.pythonSettings.linting.mypyEnabled) {
-            return Promise.resolve([]);
-        }
-
-        let mypyPath = this.pythonSettings.linting.mypyPath;
-        let mypyArgs = Array.isArray(this.pythonSettings.linting.mypyArgs) ? this.pythonSettings.linting.mypyArgs : [];
-        
-        if (mypyArgs.length === 0 && ProductExecutableAndArgs.has(Product.mypy) && mypyPath.toLocaleLowerCase() === 'mypy'){
-            mypyPath = ProductExecutableAndArgs.get(Product.mypy).executable;
-            mypyArgs = ProductExecutableAndArgs.get(Product.mypy).args;
-        }
-
-        return new Promise<baseLinter.ILintMessage[]>((resolve, reject) => {
-            this.run(mypyPath, mypyArgs.concat([document.uri.fsPath]), document, this.workspaceRootPath, cancellation, REGEX).then(messages => {
-                messages.forEach(msg => {
-                    msg.severity = this.parseMessagesSeverity(msg.type, this.pythonSettings.linting.mypyCategorySeverity);
-                    msg.code = msg.type;
-                });
-
-                resolve(messages);
-            }, reject);
-        });
+    public getExtraLinterArgs(document: TextDocument): string[] {
+        return [document.uri.fsPath];
     }
 }

--- a/src/client/linters/pep8Linter.ts
+++ b/src/client/linters/pep8Linter.ts
@@ -2,7 +2,7 @@
 
 import * as baseLinter from './baseLinter';
 import { OutputChannel } from 'vscode';
-import { Product, ProductExecutableAndArgs } from '../common/installer';
+import { Product } from '../common/installer';
 import { TextDocument, CancellationToken } from 'vscode';
 
 export class Linter extends baseLinter.BaseLinter {
@@ -12,30 +12,7 @@ export class Linter extends baseLinter.BaseLinter {
         super('pep8', Product.pep8, outputChannel, workspaceRootPath);
     }
 
-    public isEnabled(): Boolean {
-        return this.pythonSettings.linting.pep8Enabled;
-    }
-    public runLinter(document: TextDocument, cancellation: CancellationToken): Promise<baseLinter.ILintMessage[]> {
-        if (!this.pythonSettings.linting.pep8Enabled) {
-            return Promise.resolve([]);
-        }
-
-        let pep8Path = this.pythonSettings.linting.pep8Path;
-        let pep8Args = Array.isArray(this.pythonSettings.linting.pep8Args) ? this.pythonSettings.linting.pep8Args : [];
-        
-        if (pep8Args.length === 0 && ProductExecutableAndArgs.has(Product.pep8) && pep8Path.toLocaleLowerCase() === 'pep8'){
-            pep8Path = ProductExecutableAndArgs.get(Product.pep8).executable;
-            pep8Args = ProductExecutableAndArgs.get(Product.pep8).args;
-        }
-
-        return new Promise<baseLinter.ILintMessage[]>(resolve => {
-            this.run(pep8Path, pep8Args.concat(['--format=%(row)d,%(col)d,%(code).1s,%(code)s:%(text)s', document.uri.fsPath]), document, this.workspaceRootPath, cancellation).then(messages => {
-                messages.forEach(msg => {
-                    msg.severity = this.parseMessagesSeverity(msg.type, this.pythonSettings.linting.pep8CategorySeverity);
-                });
-
-                resolve(messages);
-            });
-        });
+    public getExtraLinterArgs(document: TextDocument): string[] {
+        return ['--format=%(row)d,%(col)d,%(code).1s,%(code)s:%(text)s', document.uri.fsPath];
     }
 }

--- a/src/client/linters/pydocstyle.ts
+++ b/src/client/linters/pydocstyle.ts
@@ -5,7 +5,7 @@ import * as baseLinter from './baseLinter';
 import { ILintMessage } from './baseLinter';
 import { OutputChannel } from 'vscode';
 import { execPythonFile, IS_WINDOWS } from './../common/utils';
-import { Product, ProductExecutableAndArgs } from '../common/installer';
+import { Product } from '../common/installer';
 import { TextDocument, CancellationToken } from 'vscode';
 
 export class Linter extends baseLinter.BaseLinter {
@@ -13,32 +13,8 @@ export class Linter extends baseLinter.BaseLinter {
         super('pydocstyle', Product.pydocstyle, outputChannel, workspaceRootPath);
     }
 
-    public isEnabled(): Boolean {
-        return this.pythonSettings.linting.pydocstyleEnabled;
-    }
-    public runLinter(document: TextDocument, cancellation: CancellationToken): Promise<baseLinter.ILintMessage[]> {
-        if (!this.pythonSettings.linting.pydocstyleEnabled) {
-            return Promise.resolve([]);
-        }
-
-        let pydocstylePath = this.pythonSettings.linting.pydocstylePath;
-        let pydocstyleArgs = Array.isArray(this.pythonSettings.linting.pydocstyleArgs) ? this.pythonSettings.linting.pydocstyleArgs : [];
-
-        if (pydocstyleArgs.length === 0 && ProductExecutableAndArgs.has(Product.pydocstyle) && pydocstylePath.toLocaleLowerCase() === 'pydocstyle') {
-            pydocstylePath = ProductExecutableAndArgs.get(Product.pydocstyle).executable;
-            pydocstyleArgs = ProductExecutableAndArgs.get(Product.pydocstyle).args;
-        }
-
-        return new Promise<baseLinter.ILintMessage[]>(resolve => {
-            this.run(pydocstylePath, pydocstyleArgs.concat([document.uri.fsPath]), document, null, cancellation).then(messages => {
-                // All messages in pep8 are treated as warnings for now
-                messages.forEach(msg => {
-                    msg.severity = baseLinter.LintMessageSeverity.Information;
-                });
-
-                resolve(messages);
-            });
-        });
+    public getExtraLinterArgs(document: TextDocument): string[] {
+        return [document.uri.fsPath];
     }
 
     protected run(commandLine: string, args: string[], document: TextDocument, cwd: any, cancellation: CancellationToken): Promise<ILintMessage[]> {

--- a/src/client/linters/pylama.ts
+++ b/src/client/linters/pylama.ts
@@ -2,7 +2,7 @@
 
 import * as baseLinter from './baseLinter';
 import { OutputChannel } from 'vscode';
-import { Product, ProductExecutableAndArgs } from '../common/installer';
+import { Product } from '../common/installer';
 import { TextDocument, CancellationToken } from 'vscode';
 
 const REGEX = '(?<file>.py):(?<line>\\d+):(?<column>\\d+): \\[(?<type>\\w+)\\] (?<code>\\w\\d+):? (?<message>.*)\\r?(\\n|$)';
@@ -14,31 +14,7 @@ export class Linter extends baseLinter.BaseLinter {
         super('pylama', Product.pylama, outputChannel, workspaceRootPath);
     }
 
-    public isEnabled(): Boolean {
-        return this.pythonSettings.linting.pylamaEnabled;
-    }
-    public runLinter(document: TextDocument, cancellation: CancellationToken): Promise<baseLinter.ILintMessage[]> {
-        if (!this.pythonSettings.linting.pylamaEnabled) {
-            return Promise.resolve([]);
-        }
-
-        let pylamaPath = this.pythonSettings.linting.pylamaPath;
-        let pylamaArgs = Array.isArray(this.pythonSettings.linting.pylamaArgs) ? this.pythonSettings.linting.pylamaArgs : [];
-
-        if (pylamaArgs.length === 0 && ProductExecutableAndArgs.has(Product.pylama) && pylamaPath.toLocaleLowerCase() === 'pylama') {
-            pylamaPath = ProductExecutableAndArgs.get(Product.pylama).executable;
-            pylamaArgs = ProductExecutableAndArgs.get(Product.pylama).args;
-        }
-
-        return new Promise<baseLinter.ILintMessage[]>(resolve => {
-            this.run(pylamaPath, pylamaArgs.concat(['--format=parsable', document.uri.fsPath]), document, this.workspaceRootPath, cancellation, REGEX).then(messages => {
-                // All messages in pylama are treated as warnings for now
-                messages.forEach(msg => {
-                    msg.severity = baseLinter.LintMessageSeverity.Information;
-                });
-
-                resolve(messages);
-            });
-        });
+    public getExtraLinterArgs(document: TextDocument): string[] {
+        return ['--format=parsable', document.uri.fsPath];
     }
 }

--- a/src/client/linters/pylint.ts
+++ b/src/client/linters/pylint.ts
@@ -2,7 +2,7 @@
 
 import * as baseLinter from './baseLinter';
 import { OutputChannel } from 'vscode';
-import { Product, ProductExecutableAndArgs } from '../common/installer';
+import { Product } from '../common/installer';
 import { TextDocument, CancellationToken } from 'vscode';
 
 export class Linter extends baseLinter.BaseLinter {
@@ -10,30 +10,7 @@ export class Linter extends baseLinter.BaseLinter {
         super('pylint', Product.pylint, outputChannel, workspaceRootPath);
     }
 
-    public isEnabled(): Boolean {
-        return this.pythonSettings.linting.pylintEnabled;
-    }
-    public runLinter(document: TextDocument, cancellation: CancellationToken): Promise<baseLinter.ILintMessage[]> {
-        if (!this.pythonSettings.linting.pylintEnabled) {
-            return Promise.resolve([]);
-        }
-
-        let pylintPath = this.pythonSettings.linting.pylintPath;
-        let pylintArgs = Array.isArray(this.pythonSettings.linting.pylintArgs) ? this.pythonSettings.linting.pylintArgs : [];
-
-        if (pylintArgs.length === 0 && ProductExecutableAndArgs.has(Product.pylint) && pylintPath === 'pylint') {
-            pylintPath = ProductExecutableAndArgs.get(Product.pylint).executable;
-            pylintArgs = ProductExecutableAndArgs.get(Product.pylint).args;
-        }
-
-        return new Promise<baseLinter.ILintMessage[]>((resolve, reject) => {
-            this.run(pylintPath, pylintArgs.concat(['--msg-template=\'{line},{column},{category},{msg_id}:{msg}\'', '--reports=n', '--output-format=text', document.uri.fsPath]), document, this.workspaceRootPath, cancellation).then(messages => {
-                messages.forEach(msg => {
-                    msg.severity = this.parseMessagesSeverity(msg.type, this.pythonSettings.linting.pylintCategorySeverity);
-                });
-
-                resolve(messages);
-            }, reject);
-        });
+    public getExtraLinterArgs(document: TextDocument): string[] {
+        return ['--msg-template=\'{line},{column},{category},{msg_id}:{msg}\'', '--reports=n', '--output-format=text', document.uri.fsPath];
     }
 }


### PR DESCRIPTION
Switch between running the linter command directly or running the linter module depending on the first char of the linter path config (`:`).

Please evaluate the commits individually.

Fixes #1116