### PR TITLE
Add a run file in python terminal command in execInTerminalProvider.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
 		"onCommand:python.runCurrentTestFile",
 		"onCommand:python.runFailedTests",
 		"onCommand:python.execSelectionInTerminal",
+		"onCommand:python.execInPythonTerminal",
 		"onCommand:python.execSelectionInDjangoShell",
 		"onCommand:jupyter.runSelectionLine",
 		"onCommand:jupyter.execCurrentCell",
@@ -166,6 +167,11 @@
 				"category": "Python"
 			},
 			{
+				"command": "python.execInPythonTerminal",
+				"title": "Run Python File in Python Terminal",
+				"category": "Python"
+			},
+			{
 				"command": "python.execSelectionInDjangoShell",
 				"title": "Run Selection/Line in Django Shell",
 				"category": "Python"
@@ -231,6 +237,11 @@
 					"when": "editorHasSelection && editorLangId == python"
 				},
 				{
+					"command": "python.execInPythonTerminal",
+					"group": "Python",
+					"when": "editorLangId == python"
+				},
+				{
 					"command": "python.execSelectionInDjangoShell",
 					"group": "Python",
 					"when": "editorHasSelection && editorLangId == python && python.isDjangoProject"
@@ -259,6 +270,11 @@
 				{
 					"when": "resourceLangId == python",
 					"command": "python.execInTerminal",
+					"group": "Python"
+				},
+				{
+					"when": "resourceLangId == python",
+					"command": "python.execInPythonTerminal",
 					"group": "Python"
 				}
 			]

--- a/src/client/common/constants.ts
+++ b/src/client/common/constants.ts
@@ -5,6 +5,7 @@ export namespace Commands {
     export const Set_Interpreter = 'python.setInterpreter';
     export const Exec_In_Terminal = 'python.execInTerminal';
     export const Exec_Selection_In_Terminal = 'python.execSelectionInTerminal';
+    export const Exec_In_Python_Terminal = 'python.execInPythonTerminal';
     export const Exec_Selection_In_Django_Shell = 'python.execSelectionInDjangoShell';
     export const Tests_View_UI = 'python.viewTestUI';
     export const Tests_Picker_UI = 'python.selectTestToRun';


### PR DESCRIPTION
Similar to run selection in python terminal but for an entire file, as suggested in #723 comment.

The function uses the same principle and terminal than execSelectionInTerminal but with an entire file. Thus it takes also some snippets of code from execInTerminal.

