### PR TITLE
Fixes #1064 #1144.

### DIFF
--- a/src/client/workspaceSymbols/generator.ts
+++ b/src/client/workspaceSymbols/generator.ts
@@ -42,11 +42,11 @@ export class Generator implements vscode.Disposable {
         if (path.dirname(outputFile) === source.directory) {
             outputFile = path.basename(outputFile);
         }
-        outputFile = outputFile.indexOf(' ') > 0 ? `"${outputFile}"` : outputFile;
         const outputDir = path.dirname(outputFile);
         if (!fs.existsSync(outputDir)){
             fs.mkdirSync(outputDir);
         }
+        outputFile = outputFile.indexOf(' ') > 0 ? `"${outputFile}"` : outputFile;
         args.push(`-o ${outputFile}`, '.');
         this.output.appendLine('-'.repeat(10) + 'Generating Tags' + '-'.repeat(10));
         this.output.appendLine(`${cmd} ${args.join(' ')}`);


### PR DESCRIPTION
Fixes tickets #1064 and #1144 due to too-early quoting resulting in incorrect path being returned from `path.dirname`

  