### PR TITLE
Improvements to interpreter switching and shebang detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "onCommand:python.runtests",
     "onCommand:python.debugtests",
     "onCommand:python.setInterpreter",
+    "onCommand:python.shebangInterpreter",
     "onCommand:python.viewTestUI",
     "onCommand:python.viewTestOutput",
     "onCommand:python.selectAndRunTestMethod",
@@ -118,6 +119,11 @@
       {
         "command": "python.setInterpreter",
         "title": "Select Workspace Interpreter",
+        "category": "Python"
+      },
+      {
+        "command": "python.setShebangInterpreter",
+        "title": "Set Interpreter to shebang",
         "category": "Python"
       },
       {
@@ -973,6 +979,19 @@
               "pydocstyle",
               "pylint"
             ]
+          }
+        },
+        "python.disableShebangDetection": {
+          "type": "boolean",
+          "default": false,
+          "description": "Searches for a shebang and asks to set interpreter."
+        },
+        "python.ignoreShebang": {
+          "type": "array",
+          "description": "Files where shebang should be ignored.",
+          "default": [],
+          "items": {
+            "type": "string"
           }
         },
         "python.linting.enabled": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "onCommand:python.runtests",
     "onCommand:python.debugtests",
     "onCommand:python.setInterpreter",
-    "onCommand:python.shebangInterpreter",
+    "onCommand:python.setShebangInterpreter",
     "onCommand:python.viewTestUI",
     "onCommand:python.viewTestOutput",
     "onCommand:python.selectAndRunTestMethod",

--- a/src/client/interpreter/index.ts
+++ b/src/client/interpreter/index.ts
@@ -58,7 +58,11 @@ export class InterpreterManager implements Disposable {
             pythonPath = path.join('${workspaceRoot}', path.relative(workspace.rootPath!, pythonPath));
         }
         const pythonConfig = workspace.getConfiguration('python');
-        pythonConfig.update('pythonPath', pythonPath).then(() => {
+        var configurationTarget = null;
+        if (typeof workspace.rootPath !== 'string') {
+            configurationTarget = true; 
+        }
+        pythonConfig.update('pythonPath', pythonPath, configurationTarget).then(() => {
             //Done
         }, reason => {
             window.showErrorMessage(`Failed to set 'pythonPath'. Error: ${reason.message}`);

--- a/src/client/providers/setInterpreterProvider.ts
+++ b/src/client/providers/setInterpreterProvider.ts
@@ -12,8 +12,14 @@ interface PythonPathQuickPickItem extends vscode.QuickPickItem {
 
 export class SetInterpreterProvider implements vscode.Disposable {
     private disposables: vscode.Disposable[] = [];
+    private ignoreShebangTemp: string[] = [];
     constructor(private interpreterManager: InterpreterManager) {
         this.disposables.push(vscode.commands.registerCommand("python.setInterpreter", this.setInterpreter.bind(this)));
+        this.disposables.push(vscode.commands.registerCommand("python.setShebangInterpreter", this.setShebangInterpreter.bind(this)));
+
+        vscode.workspace.onDidOpenTextDocument(this.detectShebangInterpreter.bind(this));
+        vscode.workspace.onDidSaveTextDocument(this.detectShebangInterpreter.bind(this));
+        vscode.workspace.onDidCloseTextDocument(this.removeFromIgnoreList.bind(this));
     }
     public dispose() {
         this.disposables.forEach(disposable => disposable.dispose());
@@ -58,9 +64,103 @@ export class SetInterpreterProvider implements vscode.Disposable {
     }
 
     private setInterpreter() {
-        if (typeof vscode.workspace.rootPath !== 'string') {
-            return vscode.window.showErrorMessage('Please open a workspace to select the Python Interpreter');
-        }
         this.presentQuickPick();
+    }
+
+    private setShebangInterpreter() {
+        const document = vscode.window.activeTextEditor.document;
+        let error = false;
+
+        var firstLine = document.lineAt(0);
+        if (firstLine.isEmptyOrWhitespace) {
+            error = true;
+        }
+
+        if (!error && "#!" === firstLine.text.substr(0, 2)) {
+            // Shebang detected
+            this.interpreterManager.setPythonPath(firstLine.text.substr(2).trim());
+        }
+
+        if (error) {
+            vscode.window.showErrorMessage("No shebang found.")
+        }
+    }
+
+    private removeFromIgnoreList(document: vscode.TextDocument) {
+        const index = this.ignoreShebangTemp.indexOf(document.fileName)
+        if (index > -1 ) {
+            this.ignoreShebangTemp.splice(index, 1);
+        }
+    }
+
+    private detectShebangInterpreter(document: vscode.TextDocument) {
+        if (document.languageId !== 'python' || typeof vscode.workspace.rootPath === "string") {
+            return;
+        }
+        
+        var firstLine = document.lineAt(0);
+        if (firstLine.isEmptyOrWhitespace) {
+            return;
+        }
+
+        const pythonConfig = vscode.workspace.getConfiguration('python');
+
+        // check for Shebang
+        const selectedPythonPath = pythonConfig.get("pythonPath");
+        let intendedPythonPath = null;
+        if ("#!" === firstLine.text.substr(0, 2)) {
+            // Shebang detected
+            intendedPythonPath = firstLine.text.substr(2).trim();
+        }
+        else {
+            return;
+        }
+
+        // check, if automatic interpreter switch is globally disabled
+        const disableShebangDetection = pythonConfig.get('disableShebangDetection');
+        if (disableShebangDetection) {
+            return;
+        }
+
+        // check, if the automatic interpreter switch is disabled for current file
+        const filesIgnoreAlways = pythonConfig.get('ignoreShebang', [] as string[]);
+        if (filesIgnoreAlways.indexOf(document.fileName) > -1 || this.ignoreShebangTemp.indexOf(document.fileName) > -1) {
+            return;
+        }
+
+        // check, if current interpreter is already the right one
+        if (selectedPythonPath === intendedPythonPath) {
+            return;
+        }
+
+
+        const optionChange = 'Change interpreter';
+        const optionIgnoreUntilClose = 'Ignore until close';
+        const optionIgnoreAlways = 'Ignore always';
+        const optionNeverShowAgain = `Don't ask again`;
+        const options = [optionChange, optionIgnoreUntilClose, optionIgnoreAlways, optionNeverShowAgain];
+        const nThis = this;
+
+        vscode.window.showWarningMessage('Detected another interpreter for this file!', ...options).then(item => {
+            switch(item) {
+                case optionChange: {
+                    nThis.interpreterManager.setPythonPath(intendedPythonPath);
+                    return;
+                }
+                case optionIgnoreUntilClose: {
+                    nThis.ignoreShebangTemp.push(document.fileName);
+                    return;
+                }
+                case optionIgnoreAlways: {
+                    filesIgnoreAlways.push(document.fileName);
+                    pythonConfig.update('ignoreShebang', filesIgnoreAlways, true);
+                    return;
+                }
+                case optionNeverShowAgain: {
+                    pythonConfig.update('disableShebangDetection', true);
+                    return;
+                }
+            }
+        });
     }
 }


### PR DESCRIPTION
I was annoyed that it wasn't possible to set the interpreter when no workspace was open. This pull request should fix this issue. 
Some explanations how it works:
If there is no workspace, it sets the selected interpreter in the user settings. If there is a workspace, everything works as before.

Another feature I implemented is shebang detection. If the python file has a shebang it prompts the user and asks to set the specified interpreter. The prompt appears when opening and/or saving the document. You can select to ignore this prompt until closing the document or always. It is also possible to disable this prompt globally by setting the `python.disableShebangDetection` option to `true`.

I didn't implement unit tests yet, because I don't know where to put them :D If you think it's necessary to write some, I can try contribute them too, but my typescript/javascript/nodejs knowledge is quite limited.

Maybe we should discuss if shebang detection should be disabled in workspaces, but I think it could prevent some errors, when a file has another interpreter specified in the shebang as in the workspace options.

I hope you are satisfied with the code I wrote. Feel free to contact me for improvements. I hope these features will make it into a release. Thanks for your time and work. 
