### PR TITLE
tweak Run Python File in Terminal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1461,6 +1461,11 @@
           "default": [],
           "description": "Python launch arguments to use when executing a file in the terminal."
         },
+        "python.terminal.executeWithPythonPathEnvVariable": {
+          "type": "string",
+          "default": "",
+          "description": "PYTHONPATH env variable to use when executing a file in the terminal."
+        },
         "python.jupyter.appendResults": {
           "type": "boolean",
           "default": true,

--- a/src/client/common/configSettings.ts
+++ b/src/client/common/configSettings.ts
@@ -123,6 +123,7 @@ export interface IWorkspaceSymbolSettings {
 export interface ITerminalSettings {
     executeInFileDir: boolean;
     launchArgs: string[];
+    executeWithPythonPathEnvVariable: string;
 }
 export interface JupyterSettings {
     appendResults: boolean;
@@ -325,7 +326,8 @@ export class PythonSettings extends EventEmitter implements IPythonSettings {
         // Support for travis
         this.terminal = this.terminal ? this.terminal : {
             executeInFileDir: true,
-            launchArgs: []
+            launchArgs: [],
+            executeWithPythonPathEnvVariable: ""
         };
 
         this.jupyter = pythonSettings.get<JupyterSettings>('jupyter')!;


### PR DESCRIPTION
### Problems

1. on windows `executeInFileDir` does not work on files that are on a different drive.
1. lack of the ability to set the `PYTHONPATH` for the "Run Python File in Terminal" command.
1. the terminal's cwd is "dirty" after the "Run Python File in Terminal" command was invoked.

### Description

I am developing python extensions. My tests/examples are in subfolders and some of them require the `executeInFileDir` to be set. Unfortunately problem 2. or 3. will not allow the tests/examples to import my module locally.

Problem 1. is a corner case. I believe most of the users don't run files outside of the projects root.

### Changes

- `execInTerminal` calls [`pushd` and `popd`](https://en.wikipedia.org/wiki/Pushd_and_popd) instead of `cd` when `executeInFileDir` is given (windows only).
- added `cd -` after invoking the python file to keep the original cwd. (for non windows platforms)
- a new settings is avaliable: `executeWithPythonPathEnvVariable`.
- `PYTHONPATH` can be set for "Run Python File in Terminal".
