### PR TITLE
Make pdb (alike) snippets oneliners

### DIFF
--- a/snippets/python.json
+++ b/snippets/python.json
@@ -230,12 +230,12 @@
     },
     "ipdb": {
         "prefix": "ipdb",
-        "body": "import ipdb; ipdb.set_trace()",
+        "body": "__import__('ipdb').set_trace()",
         "description": "Code snippet for ipdb debug"
     },
     "pdb": {
         "prefix": "pdb",
-        "body": "import pdb; pdb.set_trace()",
+        "body": "__import__('pdb').set_trace()",
         "description": "Code snippet for pdb debug"
     }
 }


### PR DESCRIPTION
This allows for them to be used in a lambda, and avoids warnings like
"module import not at the beginning of file" etc from linters.

It also makes it easier to remove, and the `__import__` makes it stand
out even more (when you deal with multiple `set_trace` instances).

Shameless copy of https://github.com/honza/vim-snippets/commit/755c95fa3985d97a26a94daf94d4ca11aa5f7381