### PR TITLE
Change baseLinter.REGEX to allow more code formats

### DIFF
--- a/src/client/linters/baseLinter.ts
+++ b/src/client/linters/baseLinter.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 import { ErrorHandler } from './errorHandlers/main';
 
 let NamedRegexp = null;
-const REGEX = '(?<line>\\d+),(?<column>\\d+),(?<type>\\w+),(?<code>\\w\\d+):(?<message>.*)\\r?(\\n|$)';
+const REGEX = '(?<line>\\d+),(?<column>\\d+),(?<type>\\w+),(?<code>[^:]+):(?<message>.*)\\r?(\\n|$)';
 
 export interface IRegexGroup {
     line: number;


### PR DESCRIPTION
This patch changes the REGEX to support error codes which don't match (\w\d+).

I use a program which is very similar, but not quite identical to pylint (https://chromium.googlesource.com/chromiumos/chromite/+/master/cli/cros/cros_lint.py) for my work. I've written a wrapper script to mangle its output into the format that baseLinter.ts expects, except it doesn't recognize the message names (e.g. undefined-variable) because it expects the error code to be in the form of a msg_id (e.g. E0602). There's no reason the REGEX needs to be this strict, so I propose just matching ([^:]+), i.e. everything until the colon separator character.