### PR TITLE
Remove SIGINT handler in debugger adapter, thereby preventing it from shutting down the debugger.

### DIFF
--- a/news/3 Code Health/1122.md
+++ b/news/3 Code Health/1122.md
@@ -1,0 +1,1 @@
+Remove SIGINT handler in debugger adapter, thereby preventing it from shutting down the debugger.

--- a/src/client/debugger/Main.ts
+++ b/src/client/debugger/Main.ts
@@ -55,9 +55,6 @@ export class PythonDebugger extends LoggingDebugSession {
         this.debuggerLoaded = new Promise(resolve => {
             this.debuggerLoadedPromiseResolve = resolve;
         });
-        if (!isServer) {
-            process.on('SIGINT', this.shutdown);
-        }
     }
     // tslint:disable-next-line:no-unnecessary-override
     @sendPerformanceTelemetry(PerformanceTelemetryCondition.stoppedEvent)

--- a/src/client/debugger/mainV2.ts
+++ b/src/client/debugger/mainV2.ts
@@ -225,7 +225,6 @@ class DebugManager implements Disposable {
         if (!this.isServerMode) {
             const currentProcess = this.serviceContainer.get<ICurrentProcess>(ICurrentProcess);
             currentProcess.on('SIGTERM', this.shutdown);
-            currentProcess.on('SIGINT', this.shutdown);
         }
         this.interceptProtocolMessages();
         this.startDebugSession();


### PR DESCRIPTION
Fixes #1122

This pull request:
- [x] Has a title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file
- [x] Has unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) is not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
