### PR TITLE
Add support for activation of pyenv environments

### DIFF
--- a/news/1 Enhancements/1526.md
+++ b/news/1 Enhancements/1526.md
@@ -1,0 +1,1 @@
+Add support for activation of `pyenv` environments in the Terminal.

--- a/src/client/common/serviceRegistry.ts
+++ b/src/client/common/serviceRegistry.ts
@@ -28,6 +28,7 @@ import { Bash } from './terminal/environmentActivationProviders/bash';
 import {
     CommandPromptAndPowerShell
 } from './terminal/environmentActivationProviders/commandPrompt';
+import { PyEnvActivationCommandProvider } from './terminal/environmentActivationProviders/pyenvActivationProvider';
 import { TerminalServiceFactory } from './terminal/factory';
 import { TerminalHelper } from './terminal/helper';
 import {
@@ -68,5 +69,7 @@ export function registerTypes(serviceManager: IServiceManager) {
         ITerminalActivationCommandProvider, Bash, 'bashCShellFish');
     serviceManager.addSingleton<ITerminalActivationCommandProvider>(
         ITerminalActivationCommandProvider, CommandPromptAndPowerShell, 'commandPromptAndPowerShell');
+    serviceManager.addSingleton<ITerminalActivationCommandProvider>(
+        ITerminalActivationCommandProvider, PyEnvActivationCommandProvider, 'pyenv');
     serviceManager.addSingleton<IFeatureDeprecationManager>(IFeatureDeprecationManager, FeatureDeprecationManager);
 }

--- a/src/client/common/terminal/environmentActivationProviders/pyenvActivationProvider.ts
+++ b/src/client/common/terminal/environmentActivationProviders/pyenvActivationProvider.ts
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { inject, injectable } from 'inversify';
+import { Uri } from 'vscode';
+import { IInterpreterService, InterpreterType } from '../../../interpreter/contracts';
+import { IServiceContainer } from '../../../ioc/types';
+import { ITerminalActivationCommandProvider, TerminalShellType } from '../types';
+
+@injectable()
+export class PyEnvActivationCommandProvider implements ITerminalActivationCommandProvider {
+    constructor(@inject(IServiceContainer) private readonly serviceContainer: IServiceContainer) { }
+
+    public isShellSupported(_targetShell: TerminalShellType): boolean {
+        return true;
+    }
+
+    public async getActivationCommands(resource: Uri | undefined, _: TerminalShellType): Promise<string[] | undefined> {
+        const interpreter = await this.serviceContainer.get<IInterpreterService>(IInterpreterService).getActiveInterpreter(resource);
+        if (!interpreter || interpreter.type !== InterpreterType.Pyenv || !interpreter.envName) {
+            return;
+        }
+
+        return [`pyenv shell ${interpreter.envName}`];
+    }
+}

--- a/src/test/common/terminals/pyenvActivationProvider.unit.test.ts
+++ b/src/test/common/terminals/pyenvActivationProvider.unit.test.ts
@@ -1,0 +1,102 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { expect } from 'chai';
+import * as TypeMoq from 'typemoq';
+import '../../../client/common/extensions';
+import { PyEnvActivationCommandProvider } from '../../../client/common/terminal/environmentActivationProviders/pyenvActivationProvider';
+import { ITerminalActivationCommandProvider, TerminalShellType } from '../../../client/common/terminal/types';
+import { IInterpreterService, InterpreterType, PythonInterpreter } from '../../../client/interpreter/contracts';
+import { IServiceContainer } from '../../../client/ioc/types';
+import { getNamesAndValues } from '../../../utils/enum';
+import { Architecture } from '../../../utils/platform';
+
+suite('Terminal Environment Activation pyenv', () => {
+    let serviceContainer: TypeMoq.IMock<IServiceContainer>;
+    let interpreterService: TypeMoq.IMock<IInterpreterService>;
+    let activationProvider: ITerminalActivationCommandProvider;
+
+    setup(() => {
+        serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
+        interpreterService = TypeMoq.Mock.ofType<IInterpreterService>();
+        serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IInterpreterService), TypeMoq.It.isAny())).returns(() => interpreterService.object);
+
+        activationProvider = new PyEnvActivationCommandProvider(serviceContainer.object);
+    });
+
+    test('All shells should be supported', async () => {
+        for (const item of getNamesAndValues<TerminalShellType>(TerminalShellType)) {
+            expect(activationProvider.isShellSupported(item.value)).to.equal(true, 'All shells should be supported');
+        }
+    });
+
+    test('Ensure no activation commands are returned if intrepreter info is not found', async () => {
+        interpreterService
+            .setup(i => i.getActiveInterpreter(TypeMoq.It.isAny()))
+            .returns(() => Promise.resolve(undefined))
+            .verifiable(TypeMoq.Times.once());
+
+        const activationCommands = await activationProvider.getActivationCommands(undefined, TerminalShellType.bash);
+        expect(activationCommands).to.equal(undefined, 'Activation commands should be undefined');
+    });
+
+    test('Ensure no activation commands are returned if intrepreter is not pyenv', async () => {
+        const intepreterInfo: PythonInterpreter = {
+            architecture: Architecture.Unknown,
+            path: '',
+            sysPrefix: '',
+            version: '',
+            version_info: [1, 1, 1, 'alpha'],
+            sysVersion: '',
+            type: InterpreterType.Unknown
+        };
+        interpreterService
+            .setup(i => i.getActiveInterpreter(TypeMoq.It.isAny()))
+            .returns(() => Promise.resolve(intepreterInfo))
+            .verifiable(TypeMoq.Times.once());
+
+        const activationCommands = await activationProvider.getActivationCommands(undefined, TerminalShellType.bash);
+        expect(activationCommands).to.equal(undefined, 'Activation commands should be undefined');
+    });
+
+    test('Ensure no activation commands are returned if intrepreter envName is empty', async () => {
+        const intepreterInfo: PythonInterpreter = {
+            architecture: Architecture.Unknown,
+            path: '',
+            sysPrefix: '',
+            version: '',
+            version_info: [1, 1, 1, 'alpha'],
+            sysVersion: '',
+            type: InterpreterType.Pyenv
+        };
+        interpreterService
+            .setup(i => i.getActiveInterpreter(TypeMoq.It.isAny()))
+            .returns(() => Promise.resolve(intepreterInfo))
+            .verifiable(TypeMoq.Times.once());
+
+        const activationCommands = await activationProvider.getActivationCommands(undefined, TerminalShellType.bash);
+        expect(activationCommands).to.equal(undefined, 'Activation commands should be undefined');
+    });
+
+    test('Ensure activation command is returned', async () => {
+        const intepreterInfo: PythonInterpreter = {
+            architecture: Architecture.Unknown,
+            path: '',
+            sysPrefix: '',
+            version: '',
+            version_info: [1, 1, 1, 'alpha'],
+            sysVersion: '',
+            type: InterpreterType.Pyenv,
+            envName: 'my env name'
+        };
+        interpreterService
+            .setup(i => i.getActiveInterpreter(TypeMoq.It.isAny()))
+            .returns(() => Promise.resolve(intepreterInfo))
+            .verifiable(TypeMoq.Times.once());
+
+        const activationCommands = await activationProvider.getActivationCommands(undefined, TerminalShellType.bash);
+        expect(activationCommands).to.deep.equal([`pyenv shell ${intepreterInfo.envName}`], 'Invalid Activation command');
+    });
+});


### PR DESCRIPTION
Fixes #1526

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Has unit tests & system/integration tests
- [n/a] Any new/changed dependencies in [`package.json`](https://github.com/Microsoft/vscode-python/blob/master/package.json) are pinned (e.g. `"1.2.3"`, not `"^1.2.3"` for the specified version)
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
