### PR TITLE
Fix focus problems with add new cell buttons

### DIFF
--- a/news/2 Fixes/7820.md
+++ b/news/2 Fixes/7820.md
@@ -1,0 +1,1 @@
+Fix add new cell buttons in the notebook editor to give the new cell focus.

--- a/src/datascience-ui/native-editor/nativeEditor.tsx
+++ b/src/datascience-ui/native-editor/nativeEditor.tsx
@@ -98,7 +98,8 @@ export class NativeEditor extends React.Component<INativeEditorProps, IMainState
             const cellId = this.state.cellVMs.length > 0 ? this.state.cellVMs[0].cell.id : undefined;
             const newCell = this.stateController.insertAbove(cellId, true);
             if (newCell) {
-                this.selectCell(newCell);
+                // Make async because the click changes focus.
+                setTimeout(() => this.focusCell(newCell, true), 10);
             }
         };
         const addCellLine = this.state.cellVMs.length === 0 ? null :
@@ -370,7 +371,8 @@ export class NativeEditor extends React.Component<INativeEditorProps, IMainState
             const newCell = this.stateController.insertBelow(cellVM.cell.id, true);
             this.stateController.sendCommand(NativeCommandType.AddToEnd, 'mouse');
             if (newCell) {
-                this.selectCell(newCell);
+                // Has to be async because the click will change the focus on mouse up
+                setTimeout(() => this.focusCell(newCell, true), 10);
             }
         };
         const lastLine = index === this.state.cellVMs.length - 1 ?


### PR DESCRIPTION
For #7820

Add new cell at the bottom and top of the cells was not setting focus to the newly added cell.