### PR TITLE
Fix kernel search on unix machines

### DIFF
--- a/pythonFiles/vscode_datascience_helpers/daemon/__main__.py
+++ b/pythonFiles/vscode_datascience_helpers/daemon/__main__.py
@@ -4,6 +4,7 @@
 import argparse
 import importlib
 import json
+import os
 import logging
 import logging.config
 import sys

--- a/src/client/datascience/kernel-launcher/kernelFinder.ts
+++ b/src/client/datascience/kernel-launcher/kernelFinder.ts
@@ -75,7 +75,7 @@ export class KernelFinder implements IKernelFinder {
 
             const diskSearch = this.findDiskPath(kernelName);
             const interpreterSearch = this.interpreterLocator.getInterpreters(resource, false).then((interpreters) => {
-                const interpreterPaths = interpreters.map((interp) => interp.path);
+                const interpreterPaths = interpreters.map((interp) => interp.sysPrefix);
                 return this.findInterpreterPath(interpreterPaths, kernelName);
             });
 
@@ -102,7 +102,7 @@ export class KernelFinder implements IKernelFinder {
 
         if (this.activeInterpreter) {
             return this.getKernelSpec(
-                path.join(this.activeInterpreter.path, 'share', 'jupyter', 'kernels'),
+                path.join(this.activeInterpreter.sysPrefix, 'share', 'jupyter', 'kernels'),
                 kernelName
             );
         }


### PR DESCRIPTION
For #11360

We're looking for kernels in same directory where python executable is.
This needs to be the sysPath & not executable.
On linux executable is in bin directory.
Kernels are in a directory above, but we're looking for them inside bin