### PR TITLE
Removed an unnecessary unused syntax-error line in visualstudio_py_testlauncher.py

### DIFF
--- a/pythonFiles/visualstudio_py_testlauncher.py
+++ b/pythonFiles/visualstudio_py_testlauncher.py
@@ -344,7 +344,6 @@ def main():
                                     tests = unittest.TestSuite([m])
                                     break
                         except Exception as err:
-                            errorMessage = traceback.format_exception()
                             pass
                 if tests is None:
                     tests = suite


### PR DESCRIPTION
For #

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ x] ~Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).~
-   [ x] ~Appropriate comments and documentation strings in the code.~
-   [ x] ~Has sufficient logging.~
-   [ x] ~Has telemetry for enhancements.~
-   [ x] ~Unit tests & system/integration tests are added/updated.~
-   [ x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.~
-   [ x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).~
-   [ x] ~The wiki is updated with any design decisions/details.~

The `traceback.format_exception()` call in the deleted line expects positional arguments, and therefor throws an exception which causes the unittests to break.
This happens when running a single test/class/module in certain conditions.
Since the `errorMessage` variable is assigned and never used, it is safe to remove this line completely.
