### PR TITLE
Update py/nosetest result when debugging (#15353)

### DIFF
--- a/pythonFiles/testlauncher.py
+++ b/pythonFiles/testlauncher.py
@@ -12,8 +12,14 @@ def parse_argv():
     2. Test runner, `pytest` or `nose`
     3. Rest of the arguments are passed into the test runner.
     """
+    cwd = sys.argv[1]
+    testRunner = sys.argv[2]
+    args = sys.argv[3:]
+    if testRunner == "nose":
+        # Nose expects the program name to be first argument in vargs
+        args.insert(0, sys.argv[0])
 
-    return (sys.argv[1], sys.argv[2], sys.argv[3:])
+    return (cwd, testRunner, args)
 
 
 def run(cwd, testRunner, args):

--- a/src/client/testing/common/types.ts
+++ b/src/client/testing/common/types.ts
@@ -291,7 +291,7 @@ export interface ITestRunner {
 export const IXUnitParser = Symbol('IXUnitParser');
 export interface IXUnitParser {
     // Update "tests" with the results parsed from the given file.
-    updateResultsFromXmlLogFile(tests: Tests, outputXmlFile: string): Promise<void>;
+    updateResultsFromXmlLogFile(tests: Tests, outputXmlFile: string, timeout?: number): Promise<void>;
 }
 
 export const ITestMessageService = Symbol('ITestMessageService');

--- a/src/client/testing/nosetest/runner.ts
+++ b/src/client/testing/nosetest/runner.ts
@@ -94,9 +94,7 @@ export class TestManagerRunner implements ITestManagerRunner {
                 await this.testRunner.run(NOSETEST_PROVIDER, runOptions);
             }
 
-            return options.debug
-                ? options.tests
-                : await this.updateResultsFromLogFiles(options.tests, xmlLogFile, testResultsService);
+            return await this.updateResultsFromLogFiles(options.tests, xmlLogFile, testResultsService);
         } catch (ex) {
             return Promise.reject<Tests>(ex);
         } finally {
@@ -109,7 +107,7 @@ export class TestManagerRunner implements ITestManagerRunner {
         outputXmlFile: string,
         testResultsService: ITestResultsService,
     ): Promise<Tests> {
-        await this.xUnitParser.updateResultsFromXmlLogFile(tests, outputXmlFile);
+        await this.xUnitParser.updateResultsFromXmlLogFile(tests, outputXmlFile, 5000);
         testResultsService.updateResults(tests);
         return tests;
     }

--- a/src/client/testing/pytest/runner.ts
+++ b/src/client/testing/pytest/runner.ts
@@ -90,9 +90,7 @@ export class TestManagerRunner implements ITestManagerRunner {
                 await this.testRunner.run(PYTEST_PROVIDER, runOptions);
             }
 
-            return options.debug
-                ? options.tests
-                : await this.updateResultsFromLogFiles(options.tests, xmlLogFile, testResultsService);
+            return await this.updateResultsFromLogFiles(options.tests, xmlLogFile, testResultsService);
         } catch (ex) {
             return Promise.reject<Tests>(ex);
         } finally {
@@ -105,7 +103,7 @@ export class TestManagerRunner implements ITestManagerRunner {
         outputXmlFile: string,
         testResultsService: ITestResultsService,
     ): Promise<Tests> {
-        await this.xUnitParser.updateResultsFromXmlLogFile(tests, outputXmlFile);
+        await this.xUnitParser.updateResultsFromXmlLogFile(tests, outputXmlFile, 5000);
         testResultsService.updateResults(tests);
         return tests;
     }


### PR DESCRIPTION
* Update testlauncher.py to use required program as first argument when calling
  directly in python for nosetests

* Poll for valid test result after nose/pytest completion

* Set nose/pyunit test to be updated from xml change

